### PR TITLE
Add Base extractor

### DIFF
--- a/src/roiextractors/baseextractor.py
+++ b/src/roiextractors/baseextractor.py
@@ -1,0 +1,116 @@
+from abc import ABC, abstractmethod
+from typing import Union, Tuple
+from copy import deepcopy
+import numpy as np
+from .extraction_tools import ArrayType, FloatType
+
+
+class BaseExtractor(ABC):
+
+    def __init__(self):
+        self._times = None
+
+    @abstractmethod
+    def get_image_size(self) -> Tuple[int, int]:
+        """Get the size of each image in the recording (num_rows, num_columns).
+
+        Returns
+        -------
+        image_size: tuple
+            Size of each image (num_rows, num_columns).
+        """
+        pass
+
+    @abstractmethod
+    def get_num_frames(self) -> int:
+        """Get the number of frames in the recording.
+
+        Returns
+        -------
+        num_frames: int
+            Number of frames in the recording.
+        """
+        pass
+
+    @abstractmethod
+    def get_sampling_frequency(self) -> float:
+        """Get the sampling frequency of the recording in Hz.
+
+        Returns
+        -------
+        sampling_frequency: float
+            Sampling frequency of the recording in Hz.
+        """
+        pass
+
+    def frame_to_time(self, frames: ArrayType) -> Union[FloatType, np.ndarray]:
+        """Convert user-inputted frame indices to times with units of seconds.
+
+        Parameters
+        ----------
+        frames: array-like
+            The frame or frames to be converted to times.
+
+        Returns
+        -------
+        times: float or array-like
+            The corresponding times in seconds.
+        """
+        # Default implementation
+        frames = np.asarray(frames)
+        if self._times is None:
+            return frames / self.get_sampling_frequency()
+        else:
+            return self._times[frames]
+
+    def time_to_frame(self, times: ArrayType) -> Union[FloatType, np.ndarray]:
+        """Convert a user-inputted times (in seconds) to a frame indices.
+
+        Parameters
+        ----------
+        times: array-like
+            The times (in seconds) to be converted to frame indices.
+
+        Returns
+        -------
+        frames: float or array-like
+            The corresponding frame indices.
+        """
+        # Default implementation
+        times = np.asarray(times)
+        if self._times is None:
+            return np.round(times * self.get_sampling_frequency()).astype("int64")
+        else:
+            return np.searchsorted(self._times, times).astype("int64")
+
+    def set_times(self, times: ArrayType) -> None:
+        """Set the recording times (in seconds) for each frame.
+
+        Parameters
+        ----------
+        times: array-like
+            The times in seconds for each frame
+        """
+        assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
+        self._times = np.array(times).astype("float64")
+
+    def has_time_vector(self) -> bool:
+        """Detect if the ImagingExtractor has a time vector set or not.
+
+        Returns
+        -------
+        has_times: bool
+            True if the ImagingExtractor has a time vector set, otherwise False.
+        """
+        return self._times is not None
+
+    def copy_times(self, extractor) -> None:
+        """Copy times from another extractor.
+
+        Parameters
+        ----------
+        extractor
+            The extractor from which the times will be copied.
+        """
+        if extractor._times is not None:
+            self.set_times(deepcopy(extractor._times))

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -21,12 +21,6 @@ from .extraction_tools import ArrayType, PathType, DtypeType, FloatType, IntType
 class ImagingExtractor(BaseExtractor):
     """Abstract class that contains all the meta-data and input data from the imaging data."""
 
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize the ImagingExtractor object."""
-        self._args = args
-        self._kwargs = kwargs
-        self._times = None
-
     @abstractmethod
     def get_dtype(self) -> DtypeType:
         """Get the data type of the video.

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -8,16 +8,17 @@ FrameSliceImagingExtractor
     Class to get a lazy frame slice.
 """
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Union, Optional, Tuple, get_args
 from copy import deepcopy
 
 import numpy as np
 
+from .baseextractor import BaseExtractor
 from .extraction_tools import ArrayType, PathType, DtypeType, FloatType, IntType
 
 
-class ImagingExtractor(ABC):
+class ImagingExtractor(BaseExtractor):
     """Abstract class that contains all the meta-data and input data from the imaging data."""
 
     def __init__(self, *args, **kwargs) -> None:
@@ -25,39 +26,6 @@ class ImagingExtractor(ABC):
         self._args = args
         self._kwargs = kwargs
         self._times = None
-
-    @abstractmethod
-    def get_image_size(self) -> Tuple[int, int]:
-        """Get the size of the video (num_rows, num_columns).
-
-        Returns
-        -------
-        image_size: tuple
-            Size of the video (num_rows, num_columns).
-        """
-        pass
-
-    @abstractmethod
-    def get_num_frames(self) -> int:
-        """Get the number of frames in the video.
-
-        Returns
-        -------
-        num_frames: int
-            Number of frames in the video.
-        """
-        pass
-
-    @abstractmethod
-    def get_sampling_frequency(self) -> float:
-        """Get the sampling frequency in Hz.
-
-        Returns
-        -------
-        sampling_frequency: float
-            Sampling frequency in Hz.
-        """
-        pass
 
     @abstractmethod
     def get_dtype(self) -> DtypeType:
@@ -174,78 +142,6 @@ class ImagingExtractor(ABC):
         ), f"All 'frame_idxs' must be less than the number of frames ({self.get_num_frames()}) but received {end_frame}."
 
         return start_frame, end_frame
-
-    def frame_to_time(self, frames: ArrayType) -> Union[FloatType, np.ndarray]:
-        """Convert user-inputted frame indices to times with units of seconds.
-
-        Parameters
-        ----------
-        frames: array-like
-            The frame or frames to be converted to times.
-
-        Returns
-        -------
-        times: float or array-like
-            The corresponding times in seconds.
-        """
-        # Default implementation
-        frames = np.asarray(frames)
-        if self._times is None:
-            return frames / self.get_sampling_frequency()
-        else:
-            return self._times[frames]
-
-    def time_to_frame(self, times: ArrayType) -> Union[FloatType, np.ndarray]:
-        """Convert a user-inputted times (in seconds) to a frame indices.
-
-        Parameters
-        ----------
-        times: array-like
-            The times (in seconds) to be converted to frame indices.
-
-        Returns
-        -------
-        frames: float or array-like
-            The corresponding frame indices.
-        """
-        # Default implementation
-        times = np.asarray(times)
-        if self._times is None:
-            return np.round(times * self.get_sampling_frequency()).astype("int64")
-        else:
-            return np.searchsorted(self._times, times).astype("int64")
-
-    def set_times(self, times: ArrayType) -> None:
-        """Set the recording times (in seconds) for each frame.
-
-        Parameters
-        ----------
-        times: array-like
-            The times in seconds for each frame
-        """
-        assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
-        self._times = np.array(times).astype("float64")
-
-    def has_time_vector(self) -> bool:
-        """Detect if the ImagingExtractor has a time vector set or not.
-
-        Returns
-        -------
-        has_times: bool
-            True if the ImagingExtractor has a time vector set, otherwise False.
-        """
-        return self._times is not None
-
-    def copy_times(self, extractor) -> None:
-        """Copy times from another extractor.
-
-        Parameters
-        ----------
-        extractor
-            The extractor from which the times will be copied.
-        """
-        if extractor._times is not None:
-            self.set_times(deepcopy(extractor._times))
 
     def __eq__(self, imaging_extractor2):
         image_size_equal = self.get_image_size() == imaging_extractor2.get_image_size()

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -272,50 +272,6 @@ class SegmentationExtractor(BaseExtractor):
         """
         pass
 
-    # TODO: Refactor _times methods from ImagingExtractor and SegmentationExtractor into a BaseExtractor class
-    def set_times(self, times: ArrayType):
-        """Set the recording times in seconds for each frame.
-
-        Parameters
-        ----------
-        times: array-like
-            The times in seconds for each frame
-
-        Notes
-        -----
-        Operates on _times attribute of the SegmentationExtractor object.
-        """
-        assert len(times) == self.get_num_frames(), "'times' should have the same length of the number of frames!"
-        self._times = np.array(times, dtype=np.float64)
-
-    def has_time_vector(self) -> bool:
-        """Detect if the SegmentationExtractor has a time vector set or not.
-
-        Returns
-        -------
-        has_time_vector: bool
-            True if the SegmentationExtractor has a time vector set, otherwise False.
-        """
-        return self._times is not None
-
-    def frame_to_time(self, frames: Union[IntType, ArrayType]) -> Union[FloatType, ArrayType]:
-        """Get the timing of frames in unit of seconds.
-
-        Parameters
-        ----------
-        frames: int or array-like
-            The frame or frames to be converted to times
-
-        Returns
-        -------
-        times: float or array-like
-            The corresponding times in seconds
-        """
-        if self._times is None:
-            return frames / self.get_sampling_frequency()
-        else:
-            return self._times[frames]
-
     def frame_slice(self, start_frame: Optional[int] = None, end_frame: Optional[int] = None):
         """Return a new ImagingExtractor ranging from the start_frame to the end_frame.
 

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -10,17 +10,18 @@ FrameSliceSegmentationExtractor
     Class to get a lazy frame slice.
 """
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Union, Optional, Tuple, Iterable, List, get_args
 
 import numpy as np
 from numpy.typing import ArrayLike
 
+from .baseextractor import BaseExtractor
 from .extraction_tools import ArrayType, IntType, FloatType
 from .extraction_tools import _pixel_mask_extractor
 
 
-class SegmentationExtractor(ABC):
+class SegmentationExtractor(BaseExtractor):
     """Abstract segmentation extractor class.
 
     An abstract class that contains all the meta-data and output data from
@@ -34,39 +35,6 @@ class SegmentationExtractor(ABC):
     def __init__(self):
         """Create a new SegmentationExtractor for a specific data format (unique to each child SegmentationExtractor)."""
         self._times = None
-
-    @abstractmethod
-    def get_image_size(self) -> ArrayType:
-        """Get frame size of movie (height, width).
-
-        Returns
-        -------
-        no_rois: array_like
-            2-D array: image height x image width
-        """
-        pass
-
-    @abstractmethod
-    def get_num_frames(self) -> int:
-        """Get the number of frames in the recording (duration of recording).
-
-        Returns
-        -------
-        num_frames: int
-            Number of frames in the recording.
-        """
-        pass
-
-    @abstractmethod
-    def get_sampling_frequency(self) -> float:
-        """Get the sampling frequency in Hz.
-
-        Returns
-        -------
-        sampling_frequency: float
-            Sampling frequency of the recording in Hz.
-        """
-        pass
 
     @abstractmethod
     def get_roi_ids(self) -> list:

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -32,10 +32,6 @@ class SegmentationExtractor(BaseExtractor):
     format specific classes that inherit from this.
     """
 
-    def __init__(self):
-        """Create a new SegmentationExtractor for a specific data format (unique to each child SegmentationExtractor)."""
-        self._times = None
-
     @abstractmethod
     def get_roi_ids(self) -> list:
         """Get the list of ROI ids.

--- a/tests/mixins/base_extractor_mixin.py
+++ b/tests/mixins/base_extractor_mixin.py
@@ -1,0 +1,71 @@
+import pytest
+import numpy as np
+
+
+class BaseExtractorMixin:
+    def test_get_image_size(self, extractor, expected_image_size):
+        image_size = extractor.get_image_size()
+        assert image_size == expected_image_size
+
+    def test_get_num_frames(self, extractor, expected_num_frames):
+        num_frames = extractor.get_num_frames()
+        assert num_frames == expected_num_frames
+
+    def test_get_sampling_frequency(self, extractor, expected_sampling_frequency):
+        sampling_frequency = extractor.get_sampling_frequency()
+        assert sampling_frequency == expected_sampling_frequency
+
+    @pytest.mark.parametrize("sampling_frequency", [1, 2, 3])
+    def test_frame_to_time_no_times(self, extractor, sampling_frequency):
+        extractor._times = None
+        extractor._sampling_frequency = sampling_frequency
+        times = extractor.frame_to_time(frames=[0, 1])
+        expected_times = np.array([0, 1]) / sampling_frequency
+        assert np.array_equal(times, expected_times)
+
+    def test_frame_to_time_with_times(self, extractor):
+        expected_times = np.array([0, 1])
+        extractor._times = expected_times
+        times = extractor.frame_to_time(frames=[0, 1])
+
+        assert np.array_equal(times, expected_times)
+
+    @pytest.mark.parametrize("sampling_frequency", [1, 2, 3])
+    def test_time_to_frame_no_times(self, extractor, sampling_frequency):
+        extractor._times = None
+        extractor._sampling_frequency = sampling_frequency
+        times = np.array([0, 1]) / sampling_frequency
+        frames = extractor.time_to_frame(times=times)
+        expected_frames = np.array([0, 1])
+        assert np.array_equal(frames, expected_frames)
+
+    def test_time_to_frame_with_times(self, extractor):
+        extractor._times = np.array([0, 1])
+        times = np.array([0, 1])
+        frames = extractor.time_to_frame(times=times)
+        expected_frames = np.array([0, 1])
+        assert np.array_equal(frames, expected_frames)
+
+    def test_set_times(self, extractor):
+        times = np.arange(extractor.get_num_frames())
+        extractor.set_times(times)
+        assert np.array_equal(extractor._times, times)
+
+    def test_set_times_invalid_length(self, extractor):
+        with pytest.raises(AssertionError):
+            extractor.set_times(np.arange(extractor.get_num_frames() + 1))
+
+    @pytest.mark.parametrize("times", [None, np.array([0, 1])])
+    def test_has_time_vector(self, times, extractor):
+        extractor._times = times
+        if times is None:
+            assert not extractor.has_time_vector()
+        else:
+            assert extractor.has_time_vector()
+
+    def test_copy_times(self, extractor, extractor2):
+        expected_times = np.arange(extractor.get_num_frames())
+        extractor._times = expected_times
+        extractor2.copy_times(extractor)
+        assert np.array_equal(extractor2._times, expected_times)
+        assert extractor2._times is not expected_times

--- a/tests/mixins/imaging_extractor_mixin.py
+++ b/tests/mixins/imaging_extractor_mixin.py
@@ -1,19 +1,24 @@
 import pytest
 import numpy as np
+from .base_extractor_mixin import BaseExtractorMixin
 
 
-class ImagingExtractorMixin:
-    def test_get_image_size(self, imaging_extractor, expected_video):
-        image_size = imaging_extractor.get_image_size()
-        assert image_size == (expected_video.shape[1], expected_video.shape[2])
+class ImagingExtractorMixin(BaseExtractorMixin):
+    @pytest.fixture(scope="function")
+    def extractor(self, imaging_extractor):
+        return imaging_extractor
 
-    def test_get_num_frames(self, imaging_extractor, expected_video):
-        num_frames = imaging_extractor.get_num_frames()
-        assert num_frames == expected_video.shape[0]
+    @pytest.fixture(scope="function")
+    def extractor2(self, imaging_extractor2):
+        return imaging_extractor2
 
-    def test_get_sampling_frequency(self, imaging_extractor, expected_sampling_frequency):
-        sampling_frequency = imaging_extractor.get_sampling_frequency()
-        assert sampling_frequency == expected_sampling_frequency
+    @pytest.fixture(scope="function")
+    def expected_image_size(self, expected_video):
+        return expected_video.shape[1], expected_video.shape[2]
+
+    @pytest.fixture(scope="function")
+    def expected_num_frames(self, expected_video):
+        return expected_video.shape[0]
 
     def test_get_dtype(self, imaging_extractor, expected_video):
         dtype = imaging_extractor.get_dtype()
@@ -59,61 +64,6 @@ class ImagingExtractorMixin:
             imaging_extractor.get_frames(frame_idxs=[imaging_extractor.get_num_frames()])
         with pytest.raises(AssertionError):
             imaging_extractor.get_frames(frame_idxs=[0.5])
-
-    @pytest.mark.parametrize("sampling_frequency", [1, 2, 3])
-    def test_frame_to_time_no_times(self, imaging_extractor, sampling_frequency):
-        imaging_extractor._times = None
-        imaging_extractor._sampling_frequency = sampling_frequency
-        times = imaging_extractor.frame_to_time(frames=[0, 1])
-        expected_times = np.array([0, 1]) / sampling_frequency
-        assert np.array_equal(times, expected_times)
-
-    def test_frame_to_time_with_times(self, imaging_extractor):
-        expected_times = np.array([0, 1])
-        imaging_extractor._times = expected_times
-        times = imaging_extractor.frame_to_time(frames=[0, 1])
-
-        assert np.array_equal(times, expected_times)
-
-    @pytest.mark.parametrize("sampling_frequency", [1, 2, 3])
-    def test_time_to_frame_no_times(self, imaging_extractor, sampling_frequency):
-        imaging_extractor._times = None
-        imaging_extractor._sampling_frequency = sampling_frequency
-        times = np.array([0, 1]) / sampling_frequency
-        frames = imaging_extractor.time_to_frame(times=times)
-        expected_frames = np.array([0, 1])
-        assert np.array_equal(frames, expected_frames)
-
-    def test_time_to_frame_with_times(self, imaging_extractor):
-        imaging_extractor._times = np.array([0, 1])
-        times = np.array([0, 1])
-        frames = imaging_extractor.time_to_frame(times=times)
-        expected_frames = np.array([0, 1])
-        assert np.array_equal(frames, expected_frames)
-
-    def test_set_times(self, imaging_extractor):
-        times = np.arange(imaging_extractor.get_num_frames())
-        imaging_extractor.set_times(times)
-        assert np.array_equal(imaging_extractor._times, times)
-
-    def test_set_times_invalid_length(self, imaging_extractor):
-        with pytest.raises(AssertionError):
-            imaging_extractor.set_times(np.arange(imaging_extractor.get_num_frames() + 1))
-
-    @pytest.mark.parametrize("times", [None, np.array([0, 1])])
-    def test_has_time_vector(self, times, imaging_extractor):
-        imaging_extractor._times = times
-        if times is None:
-            assert not imaging_extractor.has_time_vector()
-        else:
-            assert imaging_extractor.has_time_vector()
-
-    def test_copy_times(self, imaging_extractor, imaging_extractor2):
-        expected_times = np.arange(imaging_extractor.get_num_frames())
-        imaging_extractor._times = expected_times
-        imaging_extractor2.copy_times(imaging_extractor)
-        assert np.array_equal(imaging_extractor2._times, expected_times)
-        assert imaging_extractor2._times is not expected_times
 
     def test_eq(self, imaging_extractor, imaging_extractor2):
         assert imaging_extractor == imaging_extractor2

--- a/tests/mixins/segmentation_extractor_mixin.py
+++ b/tests/mixins/segmentation_extractor_mixin.py
@@ -1,20 +1,25 @@
 import pytest
 import numpy as np
 
+from .base_extractor_mixin import BaseExtractorMixin
 
-class SegmentationExtractorMixin:
-    def test_get_image_size(self, segmentation_extractor, expected_image_masks):
-        image_size = segmentation_extractor.get_image_size()
-        assert image_size == (expected_image_masks.shape[0], expected_image_masks.shape[1])
 
-    def test_get_num_frames(self, segmentation_extractor, expected_roi_response_traces):
-        num_frames = segmentation_extractor.get_num_frames()
-        first_expected_roi_response_trace = list(expected_roi_response_traces.values())[0]
-        assert num_frames == first_expected_roi_response_trace.shape[0]
+class SegmentationExtractorMixin(BaseExtractorMixin):
+    @pytest.fixture(scope="function")
+    def extractor(self, segmentation_extractor):
+        return segmentation_extractor
 
-    def test_get_sampling_frequency(self, segmentation_extractor, expected_sampling_frequency):
-        sampling_frequency = segmentation_extractor.get_sampling_frequency()
-        assert sampling_frequency == expected_sampling_frequency
+    @pytest.fixture(scope="function")
+    def extractor2(self, segmentation_extractor2):
+        return segmentation_extractor2
+
+    @pytest.fixture(scope="function")
+    def expected_image_size(self, expected_image_masks):
+        return expected_image_masks.shape[:2]
+
+    @pytest.fixture(scope="function")
+    def expected_num_frames(self, expected_roi_response_traces):
+        return list(expected_roi_response_traces.values())[0].shape[0]
 
     def test_get_roi_ids(self, segmentation_extractor, expected_roi_ids):
         roi_ids = segmentation_extractor.get_roi_ids()

--- a/tests/test_minimal/test_numpy_segmentation_extractor.py
+++ b/tests/test_minimal/test_numpy_segmentation_extractor.py
@@ -129,10 +129,89 @@ class TestNumpySegmentationExtractor(SegmentationExtractorMixin, FrameSliceSegme
             background_response_traces=expected_background_response_traces,
         )
 
+    @pytest.fixture(scope="function")
+    def segmentation_extractor2(
+        self,
+        expected_image_masks,
+        expected_roi_response_traces,
+        expected_summary_images,
+        expected_roi_ids,
+        expected_roi_locations,
+        expected_accepted_list,
+        expected_rejected_list,
+        expected_background_response_traces,
+        expected_background_ids,
+        expected_background_image_masks,
+        expected_sampling_frequency,
+    ):
+        return NumpySegmentationExtractor(
+            image_masks=expected_image_masks,
+            roi_response_traces=expected_roi_response_traces,
+            summary_images=expected_summary_images,
+            roi_ids=expected_roi_ids,
+            roi_locations=expected_roi_locations,
+            accepted_roi_ids=expected_accepted_list,
+            rejected_roi_ids=expected_rejected_list,
+            sampling_frequency=expected_sampling_frequency,
+            background_ids=expected_background_ids,
+            background_image_masks=expected_background_image_masks,
+            background_response_traces=expected_background_response_traces,
+        )
+
 
 class TestNumpySegmentationExtractorFromFile(SegmentationExtractorMixin, FrameSliceSegmentationExtractorMixin):
     @pytest.fixture(scope="function")
     def segmentation_extractor(
+        self,
+        expected_image_masks,
+        expected_roi_response_traces,
+        expected_summary_images,
+        expected_roi_ids,
+        expected_roi_locations,
+        expected_accepted_list,
+        expected_rejected_list,
+        expected_background_response_traces,
+        expected_background_ids,
+        expected_background_image_masks,
+        expected_sampling_frequency,
+        tmp_path,
+    ):
+        name_to_ndarray = dict(
+            image_masks=expected_image_masks,
+            background_image_masks=expected_background_image_masks,
+        )
+        name_to_file_path = {}
+        for name, ndarray in name_to_ndarray.items():
+            file_path = tmp_path / f"{name}.npy"
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            np.save(file_path, ndarray)
+            name_to_file_path[name] = file_path
+        name_to_dict_of_ndarrays = dict(
+            roi_response_traces=expected_roi_response_traces,
+            background_response_traces=expected_background_response_traces,
+            summary_images=expected_summary_images,
+        )
+        name_to_dict_of_file_paths = {}
+        for name, dict_of_ndarrays in name_to_dict_of_ndarrays.items():
+            name_to_dict_of_file_paths[name] = {}
+            for key, ndarray in dict_of_ndarrays.items():
+                file_path = tmp_path / f"{name}_{key}.npy"
+                np.save(file_path, ndarray)
+                name_to_dict_of_file_paths[name][key] = file_path
+
+        return NumpySegmentationExtractor(
+            **name_to_file_path,
+            **name_to_dict_of_file_paths,
+            roi_ids=expected_roi_ids,
+            roi_locations=expected_roi_locations,
+            accepted_roi_ids=expected_accepted_list,
+            rejected_roi_ids=expected_rejected_list,
+            sampling_frequency=expected_sampling_frequency,
+            background_ids=expected_background_ids,
+        )
+
+    @pytest.fixture(scope="function")
+    def segmentation_extractor2(
         self,
         expected_image_masks,
         expected_roi_response_traces,

--- a/tests/test_minimal/test_numpy_segmentation_extractor.py
+++ b/tests/test_minimal/test_numpy_segmentation_extractor.py
@@ -232,7 +232,7 @@ class TestNumpySegmentationExtractorFromFile(SegmentationExtractorMixin, FrameSl
         )
         name_to_file_path = {}
         for name, ndarray in name_to_ndarray.items():
-            file_path = tmp_path / f"{name}.npy"
+            file_path = tmp_path / f"{name}2.npy"
             file_path.parent.mkdir(parents=True, exist_ok=True)
             np.save(file_path, ndarray)
             name_to_file_path[name] = file_path
@@ -245,7 +245,7 @@ class TestNumpySegmentationExtractorFromFile(SegmentationExtractorMixin, FrameSl
         for name, dict_of_ndarrays in name_to_dict_of_ndarrays.items():
             name_to_dict_of_file_paths[name] = {}
             for key, ndarray in dict_of_ndarrays.items():
-                file_path = tmp_path / f"{name}_{key}.npy"
+                file_path = tmp_path / f"{name}_{key}2.npy"
                 np.save(file_path, ndarray)
                 name_to_dict_of_file_paths[name][key] = file_path
 


### PR DESCRIPTION
Awaiting #366 then will change base to 0.6.0dev.

This PR is the third of a series that implement breaking changes to fully standardize the roiextractors api and update/streamline the testing suite.  Some of the main goals include
- removing channels argument to enforce 1 channel/extractor
- Switching to modularized mixins for testing and supporting pytest fixtures/parameterization
- Standard input validation, numpy indexing for 'get' methods, etc.

This PR adds a `BaseExtractor` class and corresponding `BaseExtractorMixin` testing mixin to contain commonalities between ImagingExtractor and SegmenationExtractor (mostly methods concerned with _times).

