### PR TITLE
Small patch to fix NumpySegmentationExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+* Fixed `NumpySegmentationExtractor` to properly handle `raw=None` by adding None check before shape validation [PR #508](https://github.com/catalystneuro/roiextractors/pull/508)
 
 ### Deprecations And Removals
 

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -354,11 +354,12 @@ class NumpySegmentationExtractor(SegmentationExtractor):
             self.is_dumpable = False
             self._image_masks = image_masks
             self._roi_response_raw = raw
-            assert self._image_masks.shape[-1] == self._roi_response_raw.shape[-1], (
-                "Inconsistency between image masks and raw traces. "
-                "Image masks must be (px, py, num_rois), "
-                "traces must be (num_frames, num_rois)"
-            )
+            if self._roi_response_raw is not None:
+                assert self._image_masks.shape[-1] == self._roi_response_raw.shape[-1], (
+                    "Inconsistency between image masks and raw traces. "
+                    "Image masks must be (px, py, num_rois), "
+                    "traces must be (num_frames, num_rois)"
+                )
             self._roi_response_dff = dff
             if self._roi_response_dff is not None:
                 assert self._image_masks.shape[-1] == self._roi_response_dff.shape[-1], (


### PR DESCRIPTION
Coming from here:
https://github.com/catalystneuro/neuroconv/pull/1526

All the other responses have this guard but we left raw unguarded:

https://github.com/catalystneuro/roiextractors/blob/018b2620568af20ce37c8f1ef98a27eefc57835d/src/roiextractors/extractors/numpyextractors/numpyextractors.py#L363-L383