### PR TITLE
Update macos and python version for testing

### DIFF
--- a/.github/workflows/dev-testing.yaml
+++ b/.github/workflows/dev-testing.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13] # macos-13 is the latest version of macOS with Intel chip
+        python-version: ["3.10", "3.13"]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run full pytest with coverage
         run: pytest -n auto --dist loadscope --cov=./ --cov-report xml:./codecov.xml
-      - if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'}}
+      - if: ${{ matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'}}
         name: Upload full coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Improved `MiniscopeImagingExtractor` documentation: reorganized class vs `__init__` docstrings, clarified device folder structure, added comprehensive `has_time_vector()` docstring, and removed personal information from examples. [PR #509](https://github.com/catalystneuro/roiextractors/pull/509)
 * Refactored Miniscope imaging extractor tests to native pytest style with fixture-based temp directories and warning suppression for expected conditions [PR #501](https://github.com/catalystneuro/roiextractors/pull/501)
 * Add ruff-rules to detect non-pep585 and non pep604 annotations: (tuple, list -> tuple, list)  (Union[x, y] -> X | Y )  (Optional[x] -> x | None) [PR #500](https://github.com/catalystneuro/roiextractors/pull/500) [PR #507](https://github.com/catalystneuro/roiextractors/pull/507)
+* Add testing for mac-os 15 intel in CI [PR #518](https://github.com/catalystneuro/roiextractors/pull/518)
+* Modify testing to only test the oldest and newest python versions on each OS to reduce CI time [PR #518](https://github.com/catalystneuro/roiextractors/pull/518)
 
 
 # v0.7.0 (September 26th, 2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-  "h5py>=2.10.0,<3.15; sys_platform == 'darwin'",
-  "h5py>=2.10.0; sys_platform != 'darwin'",
+  "h5py>=2.10.0",
   "pynwb>=2.0.1",
   "tqdm>=4.48.2",
   "lazy_ops>=0.2.0",


### PR DESCRIPTION
I am also switching the testing to only test the oldest and newest python version as we do in neuroconv. @pauladkisson , what do you think?