### PR TITLE
Fix lingering references to _image_masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,15 @@
 ### Features
 
 ### Fixes
+* Fixed lingering `_image_masks` references in `get_frame_shape()` methods that were missed in PR #511 for `CnmfeSegmentationExtractor`, `LegacyExtractSegmentationExtractor`, `SimaSegmentationExtractor`, and `NwbSegmentationExtractor` [PR #487](https://github.com/catalystneuro/roiextractors/pull/487)
 
 ### Deprecations And Removals
 
 ### Improvements
+
+### Testing
+* Added tests for `CnmfeSegmentationExtractor` to cover basic functionality including `get_frame_shape()`, `get_num_rois()`, `get_roi_ids()`, and `get_traces()` [PR #487](https://github.com/catalystneuro/roiextractors/pull/487)
+* Added `get_frame_shape()` test for `LegacyExtractSegmentationExtractor` [PR #487](https://github.com/catalystneuro/roiextractors/pull/487)
 
 # v0.7.1 (October 22nd, 2025)
 

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -462,7 +462,7 @@ class NwbSegmentationExtractor(SegmentationExtractor):
         frame_shape: tuple
             Shape of the video frame (num_rows, num_columns).
         """
-        return self._image_masks.shape[:2]
+        return self._roi_masks.field_of_view_shape
 
     def get_image_shape(self):
         """Get the shape of the video frame (num_rows, num_columns).
@@ -472,7 +472,7 @@ class NwbSegmentationExtractor(SegmentationExtractor):
         image_shape: tuple
             Shape of the video frame (num_rows, num_columns).
         """
-        return self._image_masks.shape[:2]
+        return self._roi_masks.field_of_view_shape
 
     def get_image_size(self):
         warnings.warn(
@@ -481,7 +481,7 @@ class NwbSegmentationExtractor(SegmentationExtractor):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._image_masks.shape[:2]
+        return self._roi_masks.field_of_view_shape
 
     def get_native_timestamps(
         self, start_sample: int | None = None, end_sample: int | None = None

--- a/src/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -60,7 +60,7 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
         self._roi_masks = _ROIMasks(
             data=image_masks_data,
             mask_tpe="nwb-image_mask",
-            field_of_view_shape=self.get_frame_shape(),
+            field_of_view_shape=image_masks_data.shape[0:2],
             roi_id_map=roi_id_map,
         )
 
@@ -158,7 +158,7 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
         tuple
             The frame shape as (height, width).
         """
-        return self._image_masks.shape[0:2]
+        return self._roi_masks.field_of_view_shape
 
     def get_image_size(self):
         warn(

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -446,7 +446,7 @@ class LegacyExtractSegmentationExtractor(SegmentationExtractor):
         tuple
             The frame shape as (height, width).
         """
-        return self._image_masks.shape[0:2]
+        return self._roi_masks.field_of_view_shape
 
     def get_image_size(self):
         warnings.warn(

--- a/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -200,7 +200,7 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         tuple
             The frame shape as (height, width).
         """
-        return self._image_masks.shape[0:2]
+        return self._roi_masks.field_of_view_shape
 
     def get_image_size(self):
         warnings.warn(

--- a/tests/test_cnmfesegmentationextractor.py
+++ b/tests/test_cnmfesegmentationextractor.py
@@ -1,0 +1,56 @@
+"""Tests for CnmfeSegmentationExtractor."""
+
+import numpy as np
+import pytest
+
+from roiextractors.extractors.schnitzerextractor import CnmfeSegmentationExtractor
+
+from .setup_paths import OPHYS_DATA_PATH
+
+
+class TestCnmfeSegmentationExtractor:
+    """Tests for CNMFE segmentation extractor with test data from GIN."""
+
+    @pytest.fixture(scope="class")
+    def extractor(self):
+        """Create extractor instance for testing."""
+        file_path = (
+            OPHYS_DATA_PATH / "segmentation_datasets" / "cnmfe" / "2014_04_01_p203_m19_check01_cnmfeAnalysis.mat"
+        )
+        return CnmfeSegmentationExtractor(file_path=file_path)
+
+    def test_get_frame_shape(self, extractor):
+        """Test that get_frame_shape() returns correct shape."""
+        frame_shape = extractor.get_frame_shape()
+
+        # Verify the frame shape is returned correctly
+        assert len(frame_shape) == 2, "Frame shape should be 2D (height, width)"
+        assert isinstance(frame_shape[0], (int, np.integer)), "Height should be an integer"
+        assert isinstance(frame_shape[1], (int, np.integer)), "Width should be an integer"
+
+        # Frame shape should be positive integers
+        assert frame_shape[0] > 0, "Height should be positive"
+        assert frame_shape[1] > 0, "Width should be positive"
+
+        # Known dimensions for this test file
+        assert frame_shape == (250, 250), "Expected frame shape is (250, 250)"
+
+    def test_get_num_rois(self, extractor):
+        """Test that get_num_rois() returns a valid number."""
+        num_rois = extractor.get_num_rois()
+        assert isinstance(num_rois, int), "Number of ROIs should be an integer"
+        assert num_rois > 0, "Should have at least one ROI"
+
+    def test_get_roi_ids(self, extractor):
+        """Test that get_roi_ids() returns valid IDs."""
+        roi_ids = extractor.get_roi_ids()
+        assert isinstance(roi_ids, list), "ROI IDs should be a list"
+        assert len(roi_ids) == extractor.get_num_rois(), "Number of IDs should match number of ROIs"
+
+    def test_get_traces(self, extractor):
+        """Test that get_traces() returns valid trace data."""
+        traces = extractor.get_traces()
+        assert traces is not None, "Traces should not be None"
+        assert isinstance(traces, np.ndarray), "Traces should be a numpy array"
+        assert traces.ndim == 2, "Traces should be 2D (num_samples x num_rois)"
+        assert traces.shape[1] == extractor.get_num_rois(), "Number of trace columns should match number of ROIs"

--- a/tests/test_extractsegmentationextractor.py
+++ b/tests/test_extractsegmentationextractor.py
@@ -77,6 +77,19 @@ class TestExtractSegmentationExtractor(TestCase):
 
         self.assertIsInstance(extractor, extractor_class)
 
+    def test_legacy_extractor_get_frame_shape(self):
+        """Test that LegacyExtractSegmentationExtractor.get_frame_shape() works correctly."""
+        file_path = self.ophys_data_path / "2014_04_01_p203_m19_check01_extractAnalysis.mat"
+        extractor = LegacyExtractSegmentationExtractor(file_path=file_path)
+
+        frame_shape = extractor.get_frame_shape()
+        # Verify the frame shape is returned correctly
+        self.assertEqual(len(frame_shape), 2)
+        self.assertIsInstance(frame_shape[0], (int, np.integer))
+        self.assertIsInstance(frame_shape[1], (int, np.integer))
+        # The test data has known dimensions
+        assert_array_equal(frame_shape, [250, 250])
+
 
 class TestNewExtractSegmentationExtractor(TestCase):
     @classmethod


### PR DESCRIPTION
See changelog. We left lingering references to the removed _image_masks but we were not testing for them so the CI did not catch them.