### PR TITLE
Add `get_native_timestamps` functionality to nwb extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@
 * Removed deprecated `FrameSliceImagingExtractor` class (deprecated October 2025). Use `SampleSlicedImagingExtractor` instead. [PR #372](https://github.com/catalystneuro/roiextractors/pull/372)
 * Removed deprecated `channel` parameter from `get_frames()` and `get_video()` methods in all imaging extractors (deprecated August 2025). [PR #372](https://github.com/catalystneuro/roiextractors/pull/372)
 * Removed deprecated ScanImage extractor classes (deprecated October 2025): `ScanImageTiffSinglePlaneImagingExtractor`, `ScanImageTiffMultiPlaneImagingExtractor`, `ScanImageTiffSinglePlaneMultiFileImagingExtractor`, and `ScanImageTiffMultiPlaneMultiFileImagingExtractor`. Use `ScanImageImagingExtractor` instead. [PR #372](https://github.com/catalystneuro/roiextractors/pull/372)
+* Deprecated `make_nwb_metadata()` method in `NwbImagingExtractor` (will be removed on or after May 2026). [PR #526](https://github.com/catalystneuro/roiextractors/pull/526)
 
 ### Improvements
+* Implemented `get_native_timestamps()` method in `NwbImagingExtractor` to properly extract timestamps using NWB's native `get_timestamps()` method. [PR #526](https://github.com/catalystneuro/roiextractors/pull/526)
+* Removed unreachable code in `NwbImagingExtractor.__init__()` for handling unsupported data shapes. [PR #526](https://github.com/catalystneuro/roiextractors/pull/526)
 
 
 # v0.7.2 (October 23rd, 2025)

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -19,7 +19,6 @@ from pynwb.ophys import OnePhotonSeries, TwoPhotonSeries
 from ...extraction_tools import (
     ArrayType,
     PathType,
-    raise_multi_channel_or_depth_not_implemented,
 )
 from ...imagingextractor import ImagingExtractor
 from ...segmentationextractor import (
@@ -76,7 +75,6 @@ class NwbImagingExtractor(ImagingExtractor):
         assert self.photon_series.external_file is None, "Only 'raw' format is currently supported"
 
         # Load the two video structures that TwoPhotonSeries supports.
-        self._data_has_channels_axis = True
         if len(self.photon_series.data.shape) == 3:
             # Planar 2D imaging: (time, width, height)
             self._num_channels = 1
@@ -88,8 +86,6 @@ class NwbImagingExtractor(ImagingExtractor):
             self._num_channels = 1
             self._num_samples, self._columns, self._num_rows, self._num_planes = self.photon_series.data.shape
             self.is_volumetric = True
-        else:
-            raise_multi_channel_or_depth_not_implemented(extractor_name=self.extractor_name)
 
         # Set channel names (This should disambiguate which optical channel)
         self._channel_names = [i.name for i in self.photon_series.imaging_plane.optical_channel]
@@ -139,7 +135,18 @@ class NwbImagingExtractor(ImagingExtractor):
         Notes
         -----
         Metadata dictionary is stored in the nwb_metadata attribute.
+
+        .. deprecated:: 0.7.3
+            This method is deprecated and will be removed on or after May 2026.
         """
+        from warnings import warn
+
+        warn(
+            "The 'make_nwb_metadata' method is deprecated and will be removed on or after May 2026.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         # Metadata dictionary - useful for constructing a nwb file
         self.nwb_metadata = dict(
             NWBFile=dict(
@@ -231,10 +238,32 @@ class NwbImagingExtractor(ImagingExtractor):
     def get_native_timestamps(
         self, start_sample: int | None = None, end_sample: int | None = None
     ) -> np.ndarray | None:
-        # NWB files may have timestamps but need to check the specific implementation
-        # For now, return None to use calculated timestamps based on sampling frequency
-        # TODO: extract the timestamps if the MiroscopySeries has timestamps
-        return None
+        """Retrieve the original unaltered timestamps for the data.
+
+        This method uses the NWB photon series get_timestamps() method, which properly handles
+        explicit timestamps, starting_time attribute, and rate-based calculations.
+
+        Parameters
+        ----------
+        start_sample : int, optional
+            The starting sample index. If None, starts from the beginning.
+        end_sample : int, optional
+            The ending sample index. If None, goes to the end.
+
+        Returns
+        -------
+        timestamps : numpy.ndarray
+            The timestamps for the data stream.
+        """
+        # Set defaults
+        if start_sample is None:
+            start_sample = 0
+        if end_sample is None:
+            end_sample = self.get_num_samples()
+
+        # Use NWB's native get_timestamps() method which handles timestamps, starting_time, and rate
+        timestamps = self.photon_series.get_timestamps()
+        return timestamps[start_sample:end_sample]
 
     def get_num_planes(self) -> int:
         """Get the number of depth planes.


### PR DESCRIPTION
As in the title, plus, other two changes:
1) The method `make_nwb_metadata` is marked to be removed. This was form the time that we were using this library to write to NWB but is no longer necessary.
2) The tests were switched to use pytest and the mocks from the pynwb library.