### PR TITLE
Handle `get_accepted_list` with segmentation extractor properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Bruker series can now read sequences of type `TSeries Brightness Over Time Element` [PR #527](https://github.com/catalystneuro/roiextractors/pull/527)
 
 ### Deprecations And Removals
+* Deprecated `get_accepted_list()` and `get_rejected_list()` methods (will be removed in May 2026). ROI classification is now stored as properties using format-native nomenclature. Use `get_property()` instead to access format-specific acceptance data. [PR #536](https://github.com/catalystneuro/roiextractors/pull/536)
 * Deprecated `get_channel_names()` method across all extractors (will be removed on or after May 2026). The method is no longer abstract and provides a default implementation returning `["channel_0", "channel_1", ...]` before removal. [PR #530](https://github.com/catalystneuro/roiextractors/pull/530)
 * Removed deprecated `get_image_size()` method from `ImagingExtractor`, `MultiImagingExtractor`, and `VolumetricImagingExtractor` (deprecated September 2025). Use `get_image_shape()` instead. [PR #372](https://github.com/catalystneuro/roiextractors/pull/372)
 * Removed deprecated `get_num_frames()` method from `ImagingExtractor`, `MultiImagingExtractor`, and `VolumetricImagingExtractor` (deprecated September 2025). Use `get_num_samples()` instead. [PR #372](https://github.com/catalystneuro/roiextractors/pull/372)

--- a/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
+++ b/src/roiextractors/extractors/caiman/caimansegmentationextractor.py
@@ -424,34 +424,39 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
             return np.array(b_sum).reshape(FOV_shape, order="F")
         return None
 
-    def get_accepted_list(self):
-        """Get list of accepted component indices.
+    def get_accepted_list(self) -> list:
+        """Get a list of accepted ROI ids.
 
         Returns
         -------
-        list
-            List of indices for components that passed quality assessment.
-            If no quality assessment was performed, returns all component indices.
+        accepted_list: list
+            List of accepted ROI ids.
         """
-        if "idx_components" in self._estimates and not self._is_scalar_dataset(self._estimates["idx_components"]):
-            return list(self._estimates["idx_components"][:])
-        # If no quality assessment, assume all components are accepted
-        return list(range(self.get_num_rois()))
+        warnings.warn(
+            "get_accepted_list is deprecated and will be removed in May 2026. "
+            "Use get_property('is_accepted', ids) instead to access CaImAn's component classification.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        is_accepted = self.get_property("is_accepted", self.get_roi_ids())
+        return [roi_id for roi_id, accepted in zip(self.get_roi_ids(), is_accepted) if accepted]
 
-    def get_rejected_list(self):
-        """Get list of rejected component indices.
+    def get_rejected_list(self) -> list:
+        """Get a list of rejected ROI ids.
 
         Returns
         -------
-        list
-            List of indices for components that failed quality assessment.
-            Returns empty list if no quality assessment was performed.
+        rejected_list: list
+            List of rejected ROI ids.
         """
-        if "idx_components_bad" in self._estimates and not self._is_scalar_dataset(
-            self._estimates["idx_components_bad"]
-        ):
-            return list(self._estimates["idx_components_bad"][:])
-        return []
+        warnings.warn(
+            "get_rejected_list is deprecated and will be removed in May 2026. "
+            "Use get_property('is_accepted', ids) instead to access CaImAn's component classification.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        is_accepted = self.get_property("is_accepted", self.get_roi_ids())
+        return [roi_id for roi_id, accepted in zip(self.get_roi_ids(), is_accepted) if not accepted]
 
     def get_frame_shape(self) -> tuple:
         return tuple(self._params["data"]["dims"][()])
@@ -522,6 +527,17 @@ class CaimanSegmentationExtractor(SegmentationExtractor):
         as properties that can be accessed via the property interface.
         """
         roi_ids = self.get_roi_ids()
+        num_rois = len(roi_ids)
+
+        # Set is_accepted property derived from idx_components/idx_components_bad
+        is_accepted = np.zeros(num_rois, dtype=bool)
+        if "idx_components" in self._estimates and not self._is_scalar_dataset(self._estimates["idx_components"]):
+            idx_components = list(self._estimates["idx_components"][:])
+            is_accepted[idx_components] = True
+        else:
+            # If no quality assessment was performed, assume all components are accepted
+            is_accepted[:] = True
+        self.set_property(key="is_accepted", values=is_accepted, ids=roi_ids)
 
         # Set SNR values as property if available
         snr_values = self._get_snr_values()

--- a/src/roiextractors/extractors/inscopixextractors/inscopixsegmentationextractor.py
+++ b/src/roiextractors/extractors/inscopixextractors/inscopixsegmentationextractor.py
@@ -74,6 +74,11 @@ class InscopixSegmentationExtractor(SegmentationExtractor):
                 roi_id_map=roi_id_map,
             )
 
+        # Set cell_status as a property for ROI classification
+        if self.cell_set.num_cells > 0:
+            cell_status = np.array([self.cell_set.get_cell_status(i) for i in range(self.cell_set.num_cells)])
+            self.set_property("cell_status", cell_status, self._roi_ids)
+
     def get_num_rois(self) -> int:
         return self.cell_set.num_cells
 
@@ -103,20 +108,42 @@ class InscopixSegmentationExtractor(SegmentationExtractor):
         return self.get_frame_shape()
 
     def get_accepted_list(self) -> list:
-        """Get list of accepted ROI IDs (as string IDs)."""
-        accepted = []
-        for i, original_id in enumerate(self._roi_ids):
-            if self.cell_set.get_cell_status(i) == "accepted":
-                accepted.append(original_id)  # Return string IDs
-        return accepted
+        """Get a list of accepted ROI ids.
+
+        Returns
+        -------
+        accepted_list: list
+            List of accepted ROI ids.
+        """
+        warnings.warn(
+            "get_accepted_list is deprecated and will be removed in May 2026. "
+            "Use get_property('cell_status', ids) instead to access Inscopix's native classification.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self.cell_set.num_cells == 0:
+            return []
+        cell_status = self.get_property("cell_status", self.get_roi_ids())
+        return [roi_id for roi_id, status in zip(self.get_roi_ids(), cell_status) if status == "accepted"]
 
     def get_rejected_list(self) -> list:
-        """Get list of rejected ROI IDs (as string IDs)."""
-        rejected = []
-        for i, original_id in enumerate(self._roi_ids):
-            if self.cell_set.get_cell_status(i) == "rejected":
-                rejected.append(original_id)  # Return string IDs
-        return rejected
+        """Get a list of rejected ROI ids.
+
+        Returns
+        -------
+        rejected_list: list
+            List of rejected ROI ids.
+        """
+        warnings.warn(
+            "get_rejected_list is deprecated and will be removed in May 2026. "
+            "Use get_property('cell_status', ids) instead to access Inscopix's native classification.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self.cell_set.num_cells == 0:
+            return []
+        cell_status = self.get_property("cell_status", self.get_roi_ids())
+        return [roi_id for roi_id, status in zip(self.get_roi_ids(), cell_status) if status == "rejected"]
 
     def get_traces(self, roi_ids=None, start_frame=None, end_frame=None, name="raw") -> ArrayType:
         """Get traces for the specified ROIs.

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -388,26 +388,6 @@ class MinianSegmentationExtractor(SegmentationExtractor):
             return super().get_roi_ids()  # Fallback to default implementation
         return list(dataset["unit_id"])
 
-    def get_accepted_list(self) -> list:
-        """Get a list of accepted ROI ids.
-
-        Returns
-        -------
-        accepted_list: list
-            List of accepted ROI ids.
-        """
-        return self.get_roi_ids()
-
-    def get_rejected_list(self) -> list:
-        """Get a list of rejected ROI ids.
-
-        Returns
-        -------
-        rejected_list: list
-            List of rejected ROI ids.
-        """
-        return list()
-
     def get_images_dict(self) -> dict:
         """Get images as a dictionary with key as the name of the ROIResponseSeries.
 

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -392,8 +392,14 @@ class NumpySegmentationExtractor(SegmentationExtractor):
         self._roi_locs = roi_locations
         self._sampling_frequency = sampling_frequency
         self._channel_names = channel_names
-        self._rejected_list = rejected_list
-        self._accepted_list = accepted_list
+
+        # Set accepted_list and rejected_list as properties if provided
+        if accepted_list is not None:
+            is_accepted = np.array([roi_id in accepted_list for roi_id in self._roi_ids], dtype=bool)
+            self.set_property("is_accepted", is_accepted, self._roi_ids)
+        if rejected_list is not None:
+            is_rejected = np.array([roi_id in rejected_list for roi_id in self._roi_ids], dtype=bool)
+            self.set_property("is_rejected", is_rejected, self._roi_ids)
 
     @property
     def image_dims(self):
@@ -406,17 +412,43 @@ class NumpySegmentationExtractor(SegmentationExtractor):
         """
         return list(self._roi_masks.field_of_view_shape)
 
-    def get_accepted_list(self):
-        if self._accepted_list is None:
-            return self.get_roi_ids()
-        else:
-            return self._accepted_list
+    def get_accepted_list(self) -> list:
+        """Get a list of accepted ROI ids.
 
-    def get_rejected_list(self):
-        if self._rejected_list is None:
-            return [a for a in self.get_roi_ids() if a not in set(self.get_accepted_list())]
-        else:
-            return self._rejected_list
+        Returns
+        -------
+        accepted_list: list
+            List of accepted ROI ids.
+        """
+        warnings.warn(
+            "get_accepted_list is deprecated and will be removed in May 2026. "
+            "Use get_property('is_accepted', ids) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if "is_accepted" not in self.get_property_keys():
+            return list(self.get_roi_ids())
+        is_accepted = self.get_property("is_accepted", self.get_roi_ids())
+        return [roi_id for roi_id, accepted in zip(self.get_roi_ids(), is_accepted) if accepted]
+
+    def get_rejected_list(self) -> list:
+        """Get a list of rejected ROI ids.
+
+        Returns
+        -------
+        rejected_list: list
+            List of rejected ROI ids.
+        """
+        warnings.warn(
+            "get_rejected_list is deprecated and will be removed in May 2026. "
+            "Use get_property('is_rejected', ids) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if "is_rejected" not in self.get_property_keys():
+            return []
+        is_rejected = self.get_property("is_rejected", self.get_roi_ids())
+        return [roi_id for roi_id, rejected in zip(self.get_roi_ids(), is_rejected) if rejected]
 
     @property
     def roi_locations(self):

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -302,8 +302,6 @@ class NwbSegmentationExtractor(SegmentationExtractor):
             raise Exception("file does not exist")
         self.file_path = file_path
         self._roi_locs = None
-        self._accepted_list = None
-        self._rejected_list = None
         self._io = NWBHDF5IO(str(file_path), mode="r")
         self.nwbfile = self._io.read()
 
@@ -342,8 +340,8 @@ class NwbSegmentationExtractor(SegmentationExtractor):
             assert "image_mask" in ps.colnames, "Could not find any image_masks in nwbfile."
             image_masks_data = DatasetView(ps["image_mask"].data).lazy_transpose([2, 1, 0])
             self._roi_locs = ps["ROICentroids"] if "ROICentroids" in ps.colnames else None
-            self._accepted_list = ps["Accepted"].data[:] if "Accepted" in ps.colnames else None
-            self._rejected_list = ps["Rejected"].data[:] if "Rejected" in ps.colnames else None
+            accepted_data = ps["Accepted"].data[:] if "Accepted" in ps.colnames else None
+            rejected_data = ps["Rejected"].data[:] if "Rejected" in ps.colnames else None
             if hasattr(ps, "id"):
                 self._roi_ids = ps.id.data[:].tolist()
             else:
@@ -357,6 +355,12 @@ class NwbSegmentationExtractor(SegmentationExtractor):
                 field_of_view_shape=self.get_frame_shape(),
                 roi_id_map=roi_id_map,
             )
+
+            # Set accepted/rejected as properties if columns exist in NWB file
+            if accepted_data is not None:
+                self.set_property("accepted", accepted_data.astype(bool), self._roi_ids)
+            if rejected_data is not None:
+                self.set_property("rejected", rejected_data.astype(bool), self._roi_ids)
 
         # Extracting stored images as GrayscaleImages:
         self._segmentation_images = None
@@ -383,17 +387,43 @@ class NwbSegmentationExtractor(SegmentationExtractor):
         """Close the NWB file."""
         self._io.close()
 
-    def get_accepted_list(self):
-        if self._accepted_list is None:
-            return list(range(self.get_num_rois()))
-        else:
-            return np.where(self._accepted_list == 1)[0].tolist()
+    def get_accepted_list(self) -> list:
+        """Get a list of accepted ROI ids.
 
-    def get_rejected_list(self):
-        if self._rejected_list is not None:
-            rej_list = np.where(self._rejected_list == 1)[0].tolist()
-            if len(rej_list) > 0:
-                return rej_list
+        Returns
+        -------
+        accepted_list: list
+            List of accepted ROI ids.
+        """
+        warnings.warn(
+            "get_accepted_list is deprecated and will be removed in May 2026. "
+            "Use get_property('accepted', ids) instead to access NWB's acceptance data.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if "accepted" not in self.get_property_keys():
+            return list(self.get_roi_ids())
+        accepted = self.get_property("accepted", self.get_roi_ids())
+        return [roi_id for roi_id, is_accepted in zip(self.get_roi_ids(), accepted) if is_accepted]
+
+    def get_rejected_list(self) -> list:
+        """Get a list of rejected ROI ids.
+
+        Returns
+        -------
+        rejected_list: list
+            List of rejected ROI ids.
+        """
+        warnings.warn(
+            "get_rejected_list is deprecated and will be removed in May 2026. "
+            "Use get_property('rejected', ids) instead to access NWB's rejection data.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if "rejected" not in self.get_property_keys():
+            return []
+        rejected = self.get_property("rejected", self.get_roi_ids())
+        return [roi_id for roi_id, is_rejected in zip(self.get_roi_ids(), rejected) if is_rejected]
 
     def get_images_dict(self):
         """Return traces as a dictionary with key as the name of the ROIResponseSeries.

--- a/src/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/cnmfesegmentationextractor.py
@@ -143,13 +143,6 @@ class CnmfeSegmentationExtractor(SegmentationExtractor):
             charlist = [chr(i) for i in np.squeeze(self._dataset_file[self._group0[0]]["movieList"][:])]
             return "".join(charlist)
 
-    def get_accepted_list(self):
-        return list(range(self.get_num_rois()))
-
-    def get_rejected_list(self):
-        ac_set = set(self.get_accepted_list())
-        return [a for a in range(self.get_num_rois()) if a not in ac_set]
-
     def get_frame_shape(self):
         """Get the frame shape (height, width) of the movie.
 

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -272,7 +272,14 @@ class NewExtractSegmentationExtractor(
         """
         return DatasetView(self._output_struct["temporal_weights"]).lazy_transpose()
 
+    def get_roi_ids(self) -> list:
+        return list(range(self.get_num_rois()))
+
     def get_accepted_list(self) -> list:
+        """Get a list of accepted ROI ids based on non-zero spatial masks.
+
+        Note: This is computed dynamically from the current mask data.
+        """
         return [
             roi_id
             for roi_id in self.get_roi_ids()
@@ -280,13 +287,12 @@ class NewExtractSegmentationExtractor(
         ]
 
     def get_rejected_list(self) -> list:
+        """Get a list of rejected ROI ids based on empty spatial masks.
+
+        Note: This is computed dynamically from the current mask data.
+        """
         accepted_list = self.get_accepted_list()
-        rejected_list = list(set(self.get_roi_ids()) - set(accepted_list))
-
-        return rejected_list
-
-    def get_roi_ids(self) -> list:
-        return list(range(self.get_num_rois()))
+        return list(set(self.get_roi_ids()) - set(accepted_list))
 
     def get_frame_shape(self) -> ArrayType:
         """Get the frame shape (height, width) of the movie.
@@ -430,13 +436,6 @@ class LegacyExtractSegmentationExtractor(SegmentationExtractor):
         if self._dataset_file[self.output_struct_name].get("file"):
             charlist = [chr(i) for i in np.squeeze(self._dataset_file[self.output_struct_name]["file"][:])]
             return "".join(charlist)
-
-    def get_accepted_list(self):
-        return list(range(self.get_num_rois()))
-
-    def get_rejected_list(self):
-        ac_set = set(self.get_accepted_list())
-        return [a for a in range(self.get_num_rois()) if a not in ac_set]
 
     def get_frame_shape(self):
         """Get the frame shape (height, width) of the movie.

--- a/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
+++ b/src/roiextractors/extractors/simaextractor/simasegmentationextractor.py
@@ -186,12 +186,6 @@ class SimaSegmentationExtractor(SegmentationExtractor):
         summary_image = np.squeeze(self._dataset_file.time_averages[0]).T
         return np.array(summary_image).T
 
-    def get_accepted_list(self):
-        return list(range(self.get_num_rois()))
-
-    def get_rejected_list(self):
-        return [a for a in range(self.get_num_rois()) if a not in set(self.get_accepted_list())]
-
     def get_frame_shape(self):
         """Get the frame shape (height, width) of the movie.
 

--- a/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
+++ b/src/roiextractors/extractors/suite2p/suite2psegmentationextractor.py
@@ -172,6 +172,10 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
         else:
             self.iscell = self._load_npy("iscell.npy", mmap_mode="r")
 
+        # Set iscell as a property for ROI classification (first column is the binary classification)
+        if self.iscell is not None:
+            self.set_property("iscell", self.iscell[:, 0], self._roi_ids)
+
         # The name of the OpticalChannel object is "OpticalChannel" if there is only one channel, otherwise it is
         # "Chan1" or "Chan2".
         self._channel_names = ["OpticalChannel" if len(channel_names) == 1 else channel_name.capitalize()]
@@ -256,11 +260,41 @@ class Suite2pSegmentationExtractor(SegmentationExtractor):
         )
         return self.get_num_samples()
 
-    def get_accepted_list(self) -> list[int]:
-        return list(np.where(self.iscell[:, 0] == 1)[0])
+    def get_accepted_list(self) -> list:
+        """Get a list of accepted ROI ids.
 
-    def get_rejected_list(self) -> list[int]:
-        return list(np.where(self.iscell[:, 0] == 0)[0])
+        Returns
+        -------
+        accepted_list: list
+            List of accepted ROI ids.
+        """
+        warnings.warn(
+            "get_accepted_list is deprecated and will be removed in May 2026. "
+            "Use get_property('iscell', ids) instead to access Suite2p's native classification.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self.iscell is None:
+            return list(self.get_roi_ids())
+        return [roi_id for roi_id, is_cell in zip(self.get_roi_ids(), self.iscell[:, 0]) if is_cell]
+
+    def get_rejected_list(self) -> list:
+        """Get a list of rejected ROI ids.
+
+        Returns
+        -------
+        rejected_list: list
+            List of rejected ROI ids.
+        """
+        warnings.warn(
+            "get_rejected_list is deprecated and will be removed in May 2026. "
+            "Use get_property('iscell', ids) instead to access Suite2p's native classification.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self.iscell is None:
+            return []
+        return [roi_id for roi_id, is_cell in zip(self.get_roi_ids(), self.iscell[:, 0]) if not is_cell]
 
     def _correlation_image_read(self) -> np.ndarray | None:
         """Read correlation image from ops (settings) dict.

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -207,27 +207,47 @@ class SegmentationExtractor(ABC):
         self._roi_masks: _ROIMasks | None = None
         self._properties = {}
 
-    @abstractmethod
     def get_accepted_list(self) -> list:
         """Get a list of accepted ROI ids.
+
+        .. deprecated::
+            `get_accepted_list` is deprecated and will be removed in May 2026.
+            Use `get_property()` instead to access format-specific acceptance data.
 
         Returns
         -------
         accepted_list: list
             List of accepted ROI ids.
         """
-        pass
+        warnings.warn(
+            "get_accepted_list is deprecated and will be removed in May 2026. "
+            "Use get_property() instead to access format-specific acceptance data.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Default: all ROIs accepted
+        return list(self.get_roi_ids())
 
-    @abstractmethod
     def get_rejected_list(self) -> list:
         """Get a list of rejected ROI ids.
+
+        .. deprecated::
+            `get_rejected_list` is deprecated and will be removed in May 2026.
+            Use `get_property()` instead to access format-specific acceptance data.
 
         Returns
         -------
         rejected_list: list
             List of rejected ROI ids.
         """
-        pass
+        warnings.warn(
+            "get_rejected_list is deprecated and will be removed in May 2026. "
+            "Use get_property() instead to access format-specific acceptance data.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Default: no ROIs rejected
+        return []
 
     @abstractmethod
     def get_native_timestamps(
@@ -1033,11 +1053,8 @@ class SampleSlicedSegmentationExtractor(SegmentationExtractor):
         if getattr(self._parent_segmentation, "_times") is not None:
             self._times = self._parent_segmentation._times[start_sample:end_sample]
 
-    def get_accepted_list(self) -> list:
-        return self._parent_segmentation.get_accepted_list()
-
-    def get_rejected_list(self) -> list:
-        return self._parent_segmentation.get_rejected_list()
+        # Copy properties from parent (ROI properties are not affected by temporal slicing)
+        self._properties = dict(self._parent_segmentation._properties)
 
     def get_frame_shape(self) -> tuple[int, int]:
         return tuple(self._parent_segmentation.get_frame_shape())

--- a/tests/test_internals/test_properties.py
+++ b/tests/test_internals/test_properties.py
@@ -88,7 +88,9 @@ def test_getter_property_validation():
     extractor.set_property(key="quality", values=[0.8, 0.9, 0.7], ids=roi_ids)
 
     # Try to get a property with similar name that doesn't exist, the error should tell the user what is available
-    with pytest.raises(KeyError, match="Property 'quality_score' not found. Available properties: \\['quality'\\]"):
+    with pytest.raises(
+        KeyError, match=r"Property 'quality_score' not found\. Available properties: \['is_accepted', 'quality'\]"
+    ):
         extractor.get_property(key="quality_score", ids=roi_ids)
 
 


### PR DESCRIPTION
The current `get_accepted_list()` and `get_rejected_list()` abstract methods were heavily modeled after Suite2p's and I think CaImAn butd don't generalize well across different segmentation formats. Formats like Inscopix uses string status values, and formats like SIMA or CNMF-E don't have this concept at all.

Previously, [we introduced the property system](https://github.com/catalystneuro/roiextractors/pull/467) that allows flexible per-ROI metadata storage. This PR proposes using properties for ROI classification instead of abstract methods, offering several advantages: (1) we preserve provenance by keeping format-native terminology (e.g., `iscell` for Suite2p, `cell_status` for Inscopix), (2) formats without acceptance concepts (like Minian or SIMA) no longer need placeholder implementations that return meaningless defaults, and (3) the approach generalizes to non-binary cases: for example if the format stores a confidence index instead of a binary classification. 

In short, the property-based approach uses existing infrastructure, better respects source format provenance, and scales to cases where binary accepted/rejected doesn't apply.

Here a table of the property that would replace the is_accepted
| Format | Property Name | Values | Notes |
|--------|---------------|--------|-------|
| Suite2p | `iscell` | 0/1 | Native binary classification |
| CaImAn | `is_accepted` | bool | Derived from `idx_components` |
| Inscopix | `cell_status` | "accepted"/"rejected" | Native string enum |
| NewExtract | (dynamic) | - | Computed from mask content |
| Numpy | `is_accepted`, `is_rejected` | bool | If provided by user |
| SIMA, CNMF-E, Minian, LegacyExtract | (none) | - | Use base class default |
