### PR TITLE
Document timestamp API design decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/build
+docs/_build
 docs/make.bat
 docs/Makefile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecations And Removals
 
 ### Improvements
+* Added documentation for the timestamp API: a user-facing guide (`timestamps.rst`) covering `get_timestamps()` and `set_times()`, and a developer-facing design decisions page (`design_decisions.rst`) explaining the separation of `get_native_timestamps` and `get_timestamps`, why `get_native_timestamps` is abstract, and copy vs. view semantics for sliced timestamps. Updated the extractor build guides (`build_ie.rst`, `build_re.rst`) to consistently document `get_native_timestamps`. [PR #552](https://github.com/catalystneuro/roiextractors/pull/552)
 
 
 # v0.8.0 (February 10th, 2026)

--- a/docs/source/build_ie.rst
+++ b/docs/source/build_ie.rst
@@ -3,11 +3,13 @@ Build an ImagingExtractor:
 
 To build your custom ImagingExtractor to interface with a new raw image storage format from your microscope, build a custom class inheriting from a base class that enforces certain methods that need to be defined:
 
-* `get_num_samples()`: the number of image frames recorded
-* `get_image_shape()`: the y,x dimensions of a single frame
-* `get_series()`: return a continuous slice of imaging data
+* ``get_num_samples()``: the number of image frames recorded
+* ``get_image_shape()``: the y,x dimensions of a single frame
+* ``get_series()``: return a continuous slice of imaging data
 
+Additionally, if your format stores hardware timestamps, you should override:
 
+* ``get_native_timestamps()``: return the format's native timestamps, or ``None`` if unavailable (see :doc:`timestamps` for details)
 
 .. code-block:: python
 
@@ -48,3 +50,12 @@ To build your custom ImagingExtractor to interface with a new raw image storage 
             # returns the (height, width) dimensions of a single frame
             # this is the abstract method that must be implemented
             return self._data.shape[1:]
+
+        def get_native_timestamps(self, start_sample=None, end_sample=None):
+
+            # Optional: override this if your format has hardware timestamps.
+            # Return None (the default) if it does not.
+            timestamps = self._read_timestamps_from_file()
+            start = start_sample or 0
+            end = end_sample or len(timestamps)
+            return timestamps[start:end]

--- a/docs/source/build_re.rst
+++ b/docs/source/build_re.rst
@@ -4,8 +4,12 @@ Build a SegmentationExtractor:
 
 To build a custom SegmentationExtractor that interfaces with the output of a custom segmentation pipeline used for post processing the raw image data.
 
-* `get_accepted_list()`: returns a list of accepted ROIs' id numbers
-* `get_frame_shape()`: the (height, width) dimensions of the image
+* ``get_accepted_list()``: returns a list of accepted ROIs' id numbers
+* ``get_frame_shape()``: the (height, width) dimensions of the image
+
+Additionally, if your format stores hardware timestamps, you should override:
+
+* ``get_native_timestamps()``: return the format's native timestamps, or ``None`` if unavailable (see :doc:`timestamps` for details)
 
 
 .. code-block:: python
@@ -79,3 +83,12 @@ To build a custom SegmentationExtractor that interfaces with the output of a cus
             # returns the (height, width) dimensions as a tuple
             # e.g., self._image_mean.shape
             return self._image_mean.shape
+
+        def get_native_timestamps(self, start_sample=None, end_sample=None):
+
+            # Optional: override this if your format has hardware timestamps.
+            # Return None (the default) if it does not.
+            timestamps = self._read_timestamps_from_file()
+            start = start_sample or 0
+            end = end_sample or len(timestamps)
+            return timestamps[start:end]

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -41,3 +41,4 @@ More details on how to construct individual extractors can be found here:
 
    build_ie
    build_re
+   design_decisions

--- a/docs/source/design_decisions.rst
+++ b/docs/source/design_decisions.rst
@@ -1,0 +1,146 @@
+Design Decisions
+================
+
+This page documents key architectural decisions in roiextractors, including the rationale
+behind them. It is intended for future developers so they know why things are the way they are.
+
+Timestamps
+----------
+
+Roiextractors is tightly integrated with
+`NeuroConv <https://neuroconv.readthedocs.io/en/main/index.html>`_, which writes data to NWB.
+When NeuroConv decides whether to store timestamps or just a sampling rate in NWB, the
+timestamp API must satisfy three constraints:
+
+1. **Respect user intentions.** If the user (or upstream code) has explicitly set timestamps
+   via ``set_times()``, those must take priority. The user may have computed corrected timing
+   from TTL pulses or applied temporal alignment shifts, and that decision should be preserved.
+
+2. **Be faithful to the source format.** If the data format contains hardware timestamps
+   recorded by the acquisition system and the user has not used ``set_times()``, those
+   timestamps should be written to NWB.
+
+3. **Avoid unnecessary allocation.** If neither user-set nor native timestamps exist, timing
+   can only be reconstructed from the sampling rate. The API should let NeuroConv detect this
+   case without allocating a full ``np.arange(n) / sampling_frequency`` array.
+
+These three constraints create a tension. A single method like ``has_time_vector()`` that only
+checks whether ``_times`` has been cached cannot distinguish between "no timestamps were set"
+and "native timestamps exist but have not been loaded yet." Eagerly loading native timestamps at
+initialization would resolve this ambiguity, but it would increase the memory footprint of every
+extractor regardless of whether those timestamps are ever needed. To address this, the current
+solution separates the question of *provenance* (does the source format have timestamps?) from the act
+of *materializing* them.
+
+Separation of ``get_native_timestamps`` and ``get_timestamps``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To satisfy these constraints, the timestamp API separates concerns into distinct methods:
+
+- ``get_timestamps()`` provides a consistent API that always returns timestamps regardless of
+  the state of the extractor. Its contract is simple: call it, get a ``numpy.ndarray`` of times
+  in seconds. Users never need to worry about whether the format has native timestamps, whether
+  someone called ``set_times()``, or whether timing must be reconstructed from the sampling rate.
+
+- ``get_native_timestamps()`` is the method that format readers override. It answers a
+  **provenance** question: *"Does this format have hardware timestamps?"* If yes, it returns
+  them; if not, the default implementation returns ``None``. Returning ``None`` rather than
+  raising an exception lets NeuroConv distinguish "no native timestamps" from "timestamps
+  exist but failed to load". This addresses constraint 2.
+
+With this separation, downstream code can resolve all three constraints through a simple
+priority chain:
+
+.. code-block:: text
+
+  What timing information is available?
+      |
+      |-- has_time_vector()?
+      |       |
+      |       yes --> user-set timestamps (constraint 1: respect user intentions)
+      |
+      |-- get_native_timestamps() is not None?
+      |       |
+      |       yes --> hardware timestamps from the source format (constraint 2: faithful to source)
+      |
+      '-- sampling rate only (constraint 3: no unnecessary allocation)
+
+``has_time_vector()`` is a cheap check (it tests whether ``_times`` has been cached).
+``get_native_timestamps()`` is only called when the first check fails, and it returns ``None``
+immediately for formats without hardware timestamps, so no array is allocated in that case.
+When native timestamps do exist, loading them is unavoidable: any consumer that needs to decide
+between writing a rate or a full timestamp array must inspect the actual values.
+
+.. note::
+
+   The name ``get_native_timestamps`` was chosen over ``get_original_timestamps`` because the
+   latter already exists in NeuroConv with different semantics: there it returns timestamps as
+   they were at initialization, before any user modifications or temporal alignment shifts,
+   rather than indicating provenance. Using a distinct name avoids this conflict.
+
+The original discussion is in `issue #448 <https://github.com/catalystneuro/roiextractors/issues/448>`_
+and `PR #465 <https://github.com/catalystneuro/roiextractors/pull/465>`_.
+
+
+Why ``get_native_timestamps`` is abstract
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``get_native_timestamps()`` is marked ``@abstractmethod`` on both ``ImagingExtractor`` and
+``SegmentationExtractor``, even though the method body provides a default ``return None``. This
+is intentional: it forces every concrete extractor to explicitly implement the method and decide
+whether its format has hardware timestamps.
+
+Without the ``@abstractmethod`` decorator, a developer writing a new extractor could easily
+overlook ``get_native_timestamps`` entirely. Their extractor would silently inherit the default
+``return None``, and if the format *did* contain hardware timestamps, no one would notice until
+a user found incorrect timing in their NWB file. Since timestamp provenance directly determines
+what NeuroConv writes to NWB (a sampling rate vs. a full timestamps array), a silent omission
+here is a data-correctness bug.
+
+The cost of the decorator is small: extractors without native timestamps write a two-line
+override that returns ``None``. The benefit is that every extractor author is required to
+consciously opt out rather than accidentally inheriting a default they may not know exists.
+
+
+Copy vs. view semantics for sliced timestamps
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Beyond deciding *which* timestamps to store, slicing introduces a question about *how*
+timestamps are shared in memory between parent and child extractors.
+
+When an extractor is temporally sliced (e.g., via ``slice_samples()``), there are two constraints
+in tension:
+
+- We do not want to **copy** the full timestamps array into the child extractor. That would
+  duplicate memory unnecessarily.
+- But the child must be **independent** from the parent. Calling ``set_times()`` on the child
+  should not affect the parent, and vice versa.
+
+This is an instance of the general `aliasing problem
+<https://numpy.org/doc/stable/user/basics.copies.html>`_: shared mutable state risks unintended
+side effects. In NumPy, this manifests as the view vs. copy distinction. A **view**
+(``parent._times[start:end]``) is memory-efficient but shares the underlying data: in-place
+mutations on one side propagate to the other. A **copy** is safe but duplicates memory.
+
+The current implementation uses a view, so it is memory-efficient but also has the benefits of a
+copy:
+
+.. code-block:: python
+
+   self._times = self._parent_imaging._times[start_sample:end_sample]
+
+This works because of an internal contract that roiextractors must uphold: ``_times`` is only
+ever replaced wholesale (via ``set_times()``), never modified element-by-element. Consider both
+directions:
+
+- **Parent calls ``set_times()``**: the parent rebinds its ``_times`` to a new array. The
+  child's view still references the original array, so it is unaffected.
+- **Child calls ``set_times()``**: the child rebinds its ``_times`` to a new array, abandoning
+  the view. The parent's array is unaffected.
+
+In both cases, the replacement (rather than mutation) of ``_times`` means the view is either
+preserved or abandoned, never partially modified. The result is the memory efficiency of views
+with the isolation of copies.
+
+See
+`PR #498 <https://github.com/catalystneuro/roiextractors/pull/498>`_ for the original discussion.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ With this package, a user can:
    compatible
    usage
    usecase
+   timestamps
    contribute
    api/index
    licence

--- a/docs/source/timestamps.rst
+++ b/docs/source/timestamps.rst
@@ -1,0 +1,61 @@
+Timestamp Handling
+==================
+
+Getting Timestamps
+------------------
+
+To get the timestamps associated with any extractor, use ``get_timestamps()``:
+
+.. code-block:: python
+
+    from roiextractors import NwbImagingExtractor
+
+    extractor = NwbImagingExtractor(file_path="my_data.nwb")
+
+    # For each sample, get the timestamp (in seconds)
+    timestamps = extractor.get_timestamps()
+
+    # Get timestamps for a specific range of frames
+    timestamps = extractor.get_timestamps(start_sample=100, end_sample=200)
+
+This method is available on both ``ImagingExtractor`` and ``SegmentationExtractor``.
+It **always returns an array** of times in seconds. You never need to check whether timestamps
+exist before calling it. The source of those timestamps depends on the extractor:
+
+- If the user has set custom timestamps via ``set_times()``, those take priority.
+- Otherwise, if the data format stores hardware timestamps (e.g., DAQ-recorded times), those
+  are returned.
+- If neither exists, timestamps are reconstructed from the sampling frequency as
+  ``np.arange(start, end) / sampling_frequency``.
+
+This means every extractor provides timestamps, regardless of whether the underlying
+format includes them.
+
+
+Setting Custom Timestamps
+--------------------------
+
+You can override the timestamps with ``set_times()``:
+
+.. code-block:: python
+
+   import numpy as np
+
+   # Set custom timestamps (must match the number of frames)
+   custom_times = np.linspace(0, 10, extractor.get_num_samples())
+   extractor.set_times(custom_times)
+
+   # Check if custom times have been set
+   extractor.has_time_vector()  # True
+
+``set_times()`` validates that the length of the provided array matches ``get_num_samples()``.
+
+
+.. seealso::
+
+    To implement timestamps in a custom extractor, see :doc:`build_ie` or :doc:`build_re`.
+
+    For the rationale behind the timestamp API design, see :doc:`design_decisions`.
+
+    For the full method signatures and parameters, see the API reference for
+    :doc:`api/base_imagingextractors` and :doc:`api/base_segmentationextractors`.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -17,6 +17,10 @@ Features
 - ``seg_obj.get_roi_locations()``: Centroid pixel location of the ROI (Regions Of Interest) as (x,y).
 - ``seg_obj.get_num_rois()``: Total number of ROIs after segmentation operation.
 - ``seg_obj.get_roi_ids()``: Any integer tags associated with an ROI, defaults to `0:num_of_rois`
+- ``seg_obj.get_timestamps(start_sample=None, end_sample=None)``: Timestamps in seconds (always available, see :doc:`timestamps`).
+- ``seg_obj.get_native_timestamps(start_sample=None, end_sample=None)``: Format-native hardware timestamps, or ``None`` if unavailable.
+- ``seg_obj.set_times(times)``: Override timestamps with custom timing.
+- ``seg_obj.has_time_vector()``: Whether custom times have been set.
 
 SegmentationExtractor object creation
 --------------------------------------

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -265,7 +265,7 @@ class SegmentationExtractor(ABC):
         timestamps : np.ndarray or None
             The original timestamps in seconds, or None if not available.
         """
-        pass
+        return None
 
     @abstractmethod
     def get_frame_shape(self) -> ArrayType:


### PR DESCRIPTION
I wanted to collect all the design decisions around the timestamp access API into proper documentation. The rationale is currently scattered across multiple issues and PRs:

- [Issue #448](https://github.com/catalystneuro/roiextractors/issues/448): original discussion on timestamp provenance
- [PR #465](https://github.com/catalystneuro/roiextractors/pull/465): implementation of `get_native_timestamps` / `get_timestamps` separation
- [PR #498](https://github.com/catalystneuro/roiextractors/pull/498): copy vs. view semantics for sliced timestamps

This PR adds two new documentation pages:

- `timestamps.rst`: user-facing guide for `get_timestamps()` and `set_times()`
- `design_decisions.rst`: developer-facing rationale covering the separation of `get_native_timestamps` and `get_timestamps`, why `get_native_timestamps` is abstract, and copy vs. view semantics for sliced timestamps

It also updates the extractor build guides (`build_ie.rst`, `build_re.rst`) to consistently document `get_native_timestamps`.

Beyond being useful here in the repo, I want to use this documentation as a reference for discussing a similar timestamp API approach with the Neo/SpikeInterface team.
