### PR TITLE
 Remove typing indirection in extraction_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Deprecated `get_num_channels()` method in `SegmentationExtractor` (will be removed on or after September 2026). [PR #560](https://github.com/catalystneuro/roiextractors/pull/560)
 
 ### Improvements
+* Removed `ArrayType`, `DtypeType`, `FloatType`, and `NumpyArray` type aliases from `extraction_tools` and replaced all usages with direct `ArrayLike` and `DTypeLike` imports from `numpy.typing`, built-in `float`, and `np.ndarray`. [PR #568](https://github.com/catalystneuro/roiextractors/pull/568)
 * Sliced extractors (`SampleSlicedSegmentationExtractor` and `RoiSlicedSegmentationExtractor`) now use copy semantics for properties, so modifications on a child do not affect the parent and vice versa [PR #559](https://github.com/catalystneuro/roiextractors/pull/559)
 * Added documentation for the timestamp API: a user-facing guide (`timestamps.rst`) covering `get_timestamps()` and `set_times()`, and a developer-facing design decisions page (`design_decisions.rst`) explaining the separation of `get_native_timestamps` and `get_timestamps`, why `get_native_timestamps` is abstract, and copy vs. view semantics for sliced timestamps. Updated the extractor build guides (`build_ie.rst`, `build_re.rst`) to consistently document `get_native_timestamps`. [PR #552](https://github.com/catalystneuro/roiextractors/pull/552)
 

--- a/src/roiextractors/extraction_tools.py
+++ b/src/roiextractors/extraction_tools.py
@@ -21,15 +21,11 @@ import zarr
 from numpy.typing import ArrayLike, DTypeLike
 from packaging import version
 
-ArrayType = ArrayLike
 PathType = str | Path
-NumpyArray = np.ndarray
-DtypeType = DTypeLike
 IntType = int | np.integer
-FloatType = float
 
 
-def calculate_regular_series_rate(series: ArrayType, tolerance_decimals: int = 6) -> float | None:
+def calculate_regular_series_rate(series: ArrayLike, tolerance_decimals: int = 6) -> float | None:
     """Calculate the rate of a regular series from consecutive differences.
 
     If all differences between consecutive points are the same (within rounding tolerance),
@@ -205,7 +201,7 @@ class VideoStructure:
 
 
 def read_numpy_memmap_video(
-    file_path: PathType, video_structure: VideoStructure, dtype: DtypeType, offset: int = 0
+    file_path: PathType, video_structure: VideoStructure, dtype: DTypeLike, offset: int = 0
 ) -> np.array:
     """Auxiliary function to read videos from binary files.
 
@@ -240,7 +236,7 @@ def read_numpy_memmap_video(
                 frame_axis=frame_axis,
             )
 
-        dtype : DtypeType
+        dtype : DTypeLike
             The type of the data to be loaded (int, float, etc.)
         offset : int, optional
             The offset in bytes. Usually corresponds to the number of bytes occupied by the header. 0 by default.

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -13,12 +13,9 @@ from warnings import warn
 import h5py
 import numpy as np
 from lazy_ops import DatasetView
+from numpy.typing import ArrayLike
 
-from ...extraction_tools import (
-    ArrayType,
-    FloatType,
-    PathType,
-)
+from ...extraction_tools import PathType
 from ...imagingextractor import ImagingExtractor
 
 
@@ -31,10 +28,10 @@ class Hdf5ImagingExtractor(ImagingExtractor):
         self,
         file_path: PathType,
         mov_field: str = "mov",
-        sampling_frequency: FloatType = None,
-        start_time: FloatType = None,
+        sampling_frequency: float = None,
+        start_time: float = None,
         metadata: dict = None,
-        channel_names: ArrayType = None,
+        channel_names: ArrayLike = None,
     ):
         """Create an ImagingExtractor from an HDF5 file.
 

--- a/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
+++ b/src/roiextractors/extractors/memmapextractors/numpymemampextractor.py
@@ -8,8 +8,9 @@ NumpyMemmapImagingExtractor
 
 from pathlib import Path
 
+from numpy.typing import DTypeLike
+
 from roiextractors.extraction_tools import (
-    DtypeType,
     PathType,
     VideoStructure,
     read_numpy_memmap_video,
@@ -28,7 +29,7 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
         file_path: PathType,
         video_structure: VideoStructure,
         sampling_frequency: float,
-        dtype: DtypeType,
+        dtype: DTypeLike,
         offset: int = 0,
     ):
         """Create an instance of NumpyMemmapImagingExtractor.
@@ -66,7 +67,7 @@ class NumpyMemmapImagingExtractor(MemmapImagingExtractor):
 
         sampling_frequency : float, optional
             The sampling frequency.
-        dtype : DtypeType
+        dtype : DTypeLike
             The type of the data to be loaded (int, float, etc.)
         offset : int, optional
             The offset in bytes. Usually corresponds to the number of bytes occupied by the header. 0 by default.

--- a/src/roiextractors/extractors/minian/miniansegmentationextractor.py
+++ b/src/roiextractors/extractors/minian/miniansegmentationextractor.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import zarr
 
-from ...extraction_tools import FloatType, PathType
+from ...extraction_tools import PathType
 from ...segmentationextractor import (
     SegmentationExtractor,
     _ROIMasks,
@@ -316,7 +316,7 @@ class MinianSegmentationExtractor(SegmentationExtractor):
 
         return native_timestamps[start_sample:end_sample]
 
-    def sample_indices_to_time(self, sample_indices: FloatType | np.ndarray) -> FloatType | np.ndarray:
+    def sample_indices_to_time(self, sample_indices: float | np.ndarray) -> float | np.ndarray:
         """Convert user-inputted sample indices to times with units of seconds.
 
         Parameters

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -12,8 +12,9 @@ import warnings
 from pathlib import Path
 
 import numpy as np
+from numpy.typing import ArrayLike
 
-from ...extraction_tools import ArrayType, FloatType, PathType
+from ...extraction_tools import PathType
 from ...imagingextractor import ImagingExtractor
 from ...segmentationextractor import (
     SegmentationExtractor,
@@ -31,8 +32,8 @@ class NumpyImagingExtractor(ImagingExtractor):
     def __init__(
         self,
         timeseries: PathType,
-        sampling_frequency: FloatType,
-        channel_names: ArrayType = None,
+        sampling_frequency: float,
+        channel_names: ArrayLike = None,
     ):
         """Create a NumpyImagingExtractor from a .npy file.
 
@@ -40,9 +41,9 @@ class NumpyImagingExtractor(ImagingExtractor):
         ----------
         timeseries: PathType
             Path to .npy file.
-        sampling_frequency: FloatType
+        sampling_frequency: float
             Sampling frequency of the video in Hz.
-        channel_names: ArrayType
+        channel_names: ArrayLike
             List of channel names.
         """
         ImagingExtractor.__init__(self)

--- a/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
+++ b/src/roiextractors/extractors/schnitzerextractor/extractsegmentationextractor.py
@@ -298,7 +298,7 @@ class NewExtractSegmentationExtractor(
 
         Returns
         -------
-        ArrayType
+        tuple[int, int]
             The frame shape as (height, width).
         """
         return self._roi_masks.field_of_view_shape

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -15,7 +15,7 @@ import numpy as np
 from .scanimagetiff_utils import (
     _get_scanimage_reader,
 )
-from ...extraction_tools import FloatType, PathType, get_package
+from ...extraction_tools import PathType, get_package
 from ...imagingextractor import ImagingExtractor
 
 
@@ -1015,7 +1015,7 @@ class ScanImageLegacyImagingExtractor(ImagingExtractor):
     def __init__(
         self,
         file_path: PathType,
-        sampling_frequency: FloatType,
+        sampling_frequency: float,
     ):
         """Create a ScanImageLegacyImagingExtractor instance from a TIFF file produced by ScanImage.
 

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -12,7 +12,6 @@ from warnings import warn
 import numpy as np
 
 from ...extraction_tools import (
-    FloatType,
     PathType,
     get_package,
     raise_multi_channel_or_depth_not_implemented,
@@ -26,7 +25,7 @@ class TiffImagingExtractor(ImagingExtractor):
     extractor_name = "TiffImaging"
     mode = "file"
 
-    def __init__(self, file_path: PathType, sampling_frequency: FloatType):
+    def __init__(self, file_path: PathType, sampling_frequency: float):
         """Create a TiffImagingExtractor instance from a TIFF file.
 
         Parameters

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -12,9 +12,9 @@ from copy import deepcopy
 from math import prod
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 from .core_utils import _convert_bytes_to_str, _convert_seconds_to_str
-from .extraction_tools import ArrayType, FloatType
 
 
 class ImagingExtractor(ABC):
@@ -237,7 +237,7 @@ class ImagingExtractor(ABC):
         """
         pass
 
-    def get_samples(self, sample_indices: ArrayType) -> np.ndarray:
+    def get_samples(self, sample_indices: ArrayLike) -> np.ndarray:
         """Get specific samples from indices (not necessarily continuous).
 
         Parameters
@@ -319,7 +319,7 @@ class ImagingExtractor(ABC):
         sample_indices = np.arange(start_sample, end_sample)
         return sample_indices / self.get_sampling_frequency()
 
-    def time_to_sample_indices(self, times: FloatType | ArrayType) -> FloatType | np.ndarray:
+    def time_to_sample_indices(self, times: float | ArrayLike) -> float | np.ndarray:
         """Convert user-inputted times (in seconds) to sample indices.
 
         Parameters
@@ -338,7 +338,7 @@ class ImagingExtractor(ABC):
         else:
             return np.searchsorted(self._times, times).astype("int64")
 
-    def set_times(self, times: ArrayType) -> None:
+    def set_times(self, times: ArrayLike) -> None:
         """Set the recording times (in seconds) for each frame.
 
         Parameters
@@ -504,7 +504,7 @@ class SampleSlicedImagingExtractor(ImagingExtractor):
         # Inherit volumetric properties from parent
         self.is_volumetric = self._parent_imaging.is_volumetric
 
-    def get_samples(self, sample_indices: ArrayType) -> np.ndarray:
+    def get_samples(self, sample_indices: ArrayLike) -> np.ndarray:
         assert max(sample_indices) < self._num_samples, "'sample_indices' range beyond number of available samples!"
         mapped_sample_indices = np.array(sample_indices) + self._start_sample
         return self._parent_imaging.get_samples(sample_indices=mapped_sample_indices)
@@ -700,7 +700,7 @@ class _FieldOfViewSlicedImagingExtractor(ImagingExtractor):
             # 2D data: (time, height, width)
             return data[:, self._row_slice, self._column_slice]
 
-    def get_samples(self, sample_indices: ArrayType) -> np.ndarray:
+    def get_samples(self, sample_indices: ArrayLike) -> np.ndarray:
         """Get specific spatially sliced samples from indices.
 
         Parameters

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -250,6 +250,7 @@ class ImagingExtractor(ABC):
         samples: numpy.ndarray
             The samples.
         """
+        sample_indices = np.asarray(sample_indices)
         assert (
             max(sample_indices) < self.get_num_samples()
         ), "'sample_indices' range beyond number of available samples!"

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -10,8 +10,8 @@ import warnings
 from typing import Iterable
 
 import numpy as np
+from numpy.typing import ArrayLike
 
-from .extraction_tools import ArrayType, NumpyArray
 from .imagingextractor import ImagingExtractor
 
 
@@ -96,7 +96,7 @@ class MultiImagingExtractor(ImagingExtractor):
 
         return times
 
-    def _get_frames_from_an_imaging_extractor(self, extractor_index: int, sample_indices: ArrayType) -> NumpyArray:
+    def _get_frames_from_an_imaging_extractor(self, extractor_index: int, sample_indices: ArrayLike) -> np.ndarray:
         """Get samples from a single imaging extractor.
 
         Parameters

--- a/src/roiextractors/segmentationextractor.py
+++ b/src/roiextractors/segmentationextractor.py
@@ -18,8 +18,6 @@ from typing import Literal
 import numpy as np
 from numpy.typing import ArrayLike
 
-from .extraction_tools import ArrayType
-
 
 # TODO make public once API stabilizes.
 @dataclass
@@ -779,7 +777,7 @@ class SegmentationExtractor(ABC):
         """
         return self._num_planes
 
-    def set_times(self, times: ArrayType):
+    def set_times(self, times: ArrayLike):
         """Set the recording times in seconds for each frame.
 
         Parameters
@@ -840,7 +838,7 @@ class SegmentationExtractor(ABC):
         sample_indices = np.arange(start_sample, end_sample)
         return sample_indices / self.get_sampling_frequency()
 
-    def set_property(self, key: str, values: ArrayType, ids: ArrayType, *, description: str = ""):
+    def set_property(self, key: str, values: ArrayLike, ids: ArrayLike, *, description: str = ""):
         """Set property values for ROIs.
 
         Parameters
@@ -877,7 +875,7 @@ class SegmentationExtractor(ABC):
 
         self._properties[key] = _PropertyInfo(data=property_array, description=description)
 
-    def get_property(self, key: str, ids: ArrayType) -> np.ndarray:
+    def get_property(self, key: str, ids: ArrayLike) -> np.ndarray:
         """Get property values for ROIs.
 
         Parameters

--- a/src/roiextractors/testing.py
+++ b/src/roiextractors/testing.py
@@ -6,9 +6,9 @@ from typing import Literal
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.typing import DTypeLike
 
 from roiextractors import NumpyImagingExtractor, NumpySegmentationExtractor
-from roiextractors.extraction_tools import DtypeType
 
 from .imagingextractor import ImagingExtractor
 from .segmentationextractor import SegmentationExtractor
@@ -19,7 +19,7 @@ inttype = (int, np.integer)
 
 
 def generate_dummy_video(
-    size: tuple[int, int, int] | tuple[int, int, int, int], dtype: DtypeType = "uint16", seed: int = 0
+    size: tuple[int, int, int] | tuple[int, int, int, int], dtype: DTypeLike = "uint16", seed: int = 0
 ):
     """Generate a dummy video of a given size and dtype.
 
@@ -29,7 +29,7 @@ def generate_dummy_video(
         Size of the video to generate.
         For planar data: (num_frames, num_rows, num_columns)
         For volumetric data: (num_frames, num_rows, num_columns, num_planes)
-    dtype : DtypeType, optional
+    dtype : DTypeLike, optional
         Dtype of the video to generate, by default "uint16".
     seed : int, default 0
         seed for the random number generator, by default 0.
@@ -56,7 +56,7 @@ def generate_dummy_imaging_extractor(
     num_rows: int = 10,
     num_columns: int = 10,
     sampling_frequency: float = 30.0,
-    dtype: DtypeType = "uint16",
+    dtype: DTypeLike = "uint16",
     seed: int = 0,
     num_samples: int | None = 30,
     has_native_timestamps: bool = False,
@@ -74,7 +74,7 @@ def generate_dummy_imaging_extractor(
         number of columns in the video, by default 10.
     sampling_frequency : float, optional
         sampling frequency of the video, by default 30.
-    dtype : DtypeType, optional
+    dtype : DTypeLike, optional
         dtype of the video, by default "uint16".
     seed : int, default 0
         seed for the random number generator, by default 0.


### PR DESCRIPTION
A requested by @pauladkisson comment on #563 noted that the `ArrayType`, `DtypeType`, `FloatType`, and `NumpyArray` aliases in `extraction_tools` were originally hand-rolled unions predating `numpy.typing`, then swapped to `ArrayLike`/`DTypeLike` in #131 but kept under the old names, adding indirection without benefit. This PR removes all four aliases and replaces their usages with direct imports of `ArrayLike` and `DTypeLike` from `numpy.typing`, built-in `float`, and `np.ndarray`.
