### PR TITLE
Remove `get_channel_names` on base `ImagingExtractor` and clean up consistency checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `mask_type` and `native_timestamps` parameters to `generate_dummy_segmentation_extractor()`. `mask_type` supports `"image"` (default) and `"pixel"` for testing sparse pixel mask workflows. `native_timestamps` supports `"evenly_spaced"` and `"unevenly_spaced"` for testing timestamp round-trips. [PR #561](https://github.com/catalystneuro/roiextractors/pull/561)
 
 ### Fixes
+* Removed `get_channel_names` from the base `ImagingExtractor` class. The implementation was broken for any extractor not defining `get_num_channels`. All concrete extractors already have their own deprecated override. `MultiImagingExtractor` and `VolumetricImagingExtractor` no longer enforce matching channel names across child extractors. `MemmapImagingExtractor` and `TiffImagingExtractor` now have their own deprecated `get_channel_names` (will be removed in or after October 2026). [PR #570](https://github.com/catalystneuro/roiextractors/pull/570)
 * Fixed return type annotations that incorrectly used `ArrayLike`/`DTypeLike` (meant for inputs) instead of concrete `np.ndarray`/`np.dtype` for outputs. Also fixed several potentially unbound variables that could crash at runtime. [PR #563](https://github.com/catalystneuro/roiextractors/pull/563)
 
 ### Deprecations And Removals

--- a/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
+++ b/src/roiextractors/extractors/hdf5imagingextractor/hdf5imagingextractor.py
@@ -127,6 +127,7 @@ class Hdf5ImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self):
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
+++ b/src/roiextractors/extractors/inscopixextractors/inscopiximagingextractor.py
@@ -63,6 +63,7 @@ class InscopixImagingExtractor(ImagingExtractor):
         return 1 / self.movie.timing.period.secs_float
 
     def get_channel_names(self) -> list[str]:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/memmapextractors/memmapextractors.py
+++ b/src/roiextractors/extractors/memmapextractors/memmapextractors.py
@@ -6,6 +6,8 @@ MemmapImagingExtractor
     The base class for memmapable imaging extractors.
 """
 
+import warnings
+
 import numpy as np
 
 from ...imagingextractor import ImagingExtractor
@@ -57,6 +59,15 @@ class MemmapImagingExtractor(ImagingExtractor):
 
     def get_dtype(self) -> np.dtype:
         return self.dtype
+
+    def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
+        warnings.warn(
+            "get_channel_names is deprecated and will be removed in or after October 2026.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return [f"channel_{i}" for i in range(self._num_channels)]
 
     def get_volume_shape(self) -> tuple[int, int, int, int]:
         """Return the shape of the video data.

--- a/src/roiextractors/extractors/numpyextractors/numpyextractors.py
+++ b/src/roiextractors/extractors/numpyextractors/numpyextractors.py
@@ -135,6 +135,7 @@ class NumpyImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self):
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/nwbextractors/nwbextractors.py
+++ b/src/roiextractors/extractors/nwbextractors/nwbextractors.py
@@ -192,6 +192,7 @@ class NwbImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self):
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
+++ b/src/roiextractors/extractors/sbximagingextractor/sbximagingextractor.py
@@ -185,6 +185,7 @@ class SbxImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/brukertiffimagingextractor.py
@@ -521,6 +521,7 @@ class BrukerTiffSinglePlaneImagingExtractor(MultiImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self) -> list[str]:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,
@@ -581,6 +582,7 @@ class _BrukerTiffSinglePlaneImagingExtractor(ImagingExtractor):
         raise NotImplementedError(self.SAMPLING_FREQ_ERROR.format(self.extractor_name))
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/micromanagertiffimagingextractor.py
@@ -176,6 +176,7 @@ class MicroManagerTiffImagingExtractor(MultiImagingExtractor):
         return self._num_samples
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,
@@ -237,6 +238,7 @@ class _MicroManagerTiffImagingExtractor(ImagingExtractor):
         raise NotImplementedError(self.SAMPLING_FREQ_ERROR.format(self.extractor_name))
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/tiffimagingextractors/multitiffmultipageextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/multitiffmultipageextractor.py
@@ -513,6 +513,7 @@ class MultiTIFFMultiPageExtractor(ImagingExtractor):
         return None
 
     def get_channel_names(self):
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/scanimagetiffimagingextractor.py
@@ -675,6 +675,7 @@ class ScanImageImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self):
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,
@@ -1097,6 +1098,7 @@ class ScanImageLegacyImagingExtractor(ImagingExtractor):
         return self._sampling_frequency
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
+++ b/src/roiextractors/extractors/tiffimagingextractors/tiffimagingextractor.py
@@ -100,6 +100,15 @@ class TiffImagingExtractor(ImagingExtractor):
     def get_sampling_frequency(self):
         return self._sampling_frequency
 
+    def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
+        warn(
+            "get_channel_names is deprecated and will be removed in or after October 2026.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return [f"channel_{i}" for i in range(self._num_channels)]
+
     def get_native_timestamps(
         self, start_sample: int | None = None, end_sample: int | None = None
     ) -> np.ndarray | None:

--- a/src/roiextractors/imagingextractor.py
+++ b/src/roiextractors/imagingextractor.py
@@ -179,16 +179,6 @@ class ImagingExtractor(ABC):
         """
         pass
 
-    def get_channel_names(self) -> list:
-        """Get the channel names in the recoding.
-
-        Returns
-        -------
-        channel_names: list
-            List of strings of channel names
-        """
-        return [f"channel_{i}" for i in range(self.get_num_channels())]
-
     def get_dtype(self) -> np.dtype:
         """Get the data type of the video.
 
@@ -538,6 +528,7 @@ class SampleSlicedImagingExtractor(ImagingExtractor):
         return self._parent_imaging.get_sampling_frequency()
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/multiimagingextractor.py
+++ b/src/roiextractors/multiimagingextractor.py
@@ -61,13 +61,11 @@ class MultiImagingExtractor(ImagingExtractor):
         This method checks the following properties:
             - sampling frequency
             - sample shape (image size and number of channels)
-            - channel names
             - data type
         """
         properties_to_check = dict(
             get_sampling_frequency="The sampling frequency",
             get_sample_shape="The shape of a sample",
-            get_channel_names="The name of the channels",
             get_dtype="The data type",
         )
         for method, property_message in properties_to_check.items():
@@ -195,6 +193,7 @@ class MultiImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_sampling_frequency()
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/src/roiextractors/volumetricimagingextractor.py
+++ b/src/roiextractors/volumetricimagingextractor.py
@@ -50,14 +50,12 @@ class VolumetricImagingExtractor(ImagingExtractor):
             - sampling frequency
             - image size
             - number of channels
-            - channel names
             - data type
             - num_frames
         """
         properties_to_check = dict(
             get_sampling_frequency="The sampling frequency",
             get_image_shape="The shape of a frame",
-            get_channel_names="The name of the channels",
             get_dtype="The data type",
             get_num_samples="The number of samples",
         )
@@ -118,6 +116,7 @@ class VolumetricImagingExtractor(ImagingExtractor):
         return self._imaging_extractors[0].get_sampling_frequency()
 
     def get_channel_names(self) -> list:
+        """Return the channel names (deprecated)."""
         warnings.warn(
             "get_channel_names is deprecated and will be removed in May 2026 or after.",
             category=FutureWarning,

--- a/tests/test_internals/test_field_of_view_slicing.py
+++ b/tests/test_internals/test_field_of_view_slicing.py
@@ -82,7 +82,6 @@ class TestFieldOfViewSlicing2D:
 
         assert fov_sliced.get_num_samples() == imaging.get_num_samples()
         assert fov_sliced.get_sampling_frequency() == imaging.get_sampling_frequency()
-        assert fov_sliced.get_channel_names() == imaging.get_channel_names()
         assert fov_sliced.get_dtype() == imaging.get_dtype()
 
     def test_set_timestamps_preservation(self):
@@ -302,6 +301,5 @@ class TestFieldOfViewSlicingVolumetric:
 
         assert fov_sliced.get_num_samples() == volumetric.get_num_samples()
         assert fov_sliced.get_sampling_frequency() == volumetric.get_sampling_frequency()
-        assert fov_sliced.get_channel_names() == volumetric.get_channel_names()
         assert fov_sliced.get_dtype() == volumetric.get_dtype()
         assert fov_sliced.is_volumetric == volumetric.is_volumetric

--- a/tests/test_internals/test_frame_slice_imaging.py
+++ b/tests/test_internals/test_frame_slice_imaging.py
@@ -39,9 +39,6 @@ class TestFrameSliceImaging(TestCase):
     def test_get_sampling_frequency(self):
         assert self.frame_sliced_imaging.get_sampling_frequency() == 30.0
 
-    def test_get_channel_names(self):
-        assert self.frame_sliced_imaging.get_channel_names() == ["channel_num_0"]
-
     def test_get_samples_assertion(self):
         with self.assertRaisesWith(
             exc_type=AssertionError, exc_msg="'sample_indices' range beyond number of available samples!"

--- a/tests/test_internals/test_multiimagingextractor.py
+++ b/tests/test_internals/test_multiimagingextractor.py
@@ -27,9 +27,6 @@ class TestMultiImagingExtractor(TestCase):
     def test_get_sampling_frequency(self):
         assert self.multi_imaging_extractor.get_sampling_frequency() == 20.0
 
-    def test_get_channel_names(self):
-        assert self.multi_imaging_extractor.get_channel_names() == ["channel_num_0"]
-
     @parameterized.expand(
         [
             param(  # All 3

--- a/tests/test_internals/test_slice_samples_imaging.py
+++ b/tests/test_internals/test_slice_samples_imaging.py
@@ -39,12 +39,6 @@ def test_get_sampling_frequency():
     assert sample_sliced_imaging.get_sampling_frequency() == 30.0
 
 
-def test_get_channel_names():
-    imaging_extractor = generate_dummy_imaging_extractor(num_samples=10, num_rows=5, num_columns=4)
-    sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)
-    assert sample_sliced_imaging.get_channel_names() == ["channel_num_0"]
-
-
 def test_get_samples_assertion():
     imaging_extractor = generate_dummy_imaging_extractor(num_samples=10, num_rows=5, num_columns=4)
     sample_sliced_imaging = imaging_extractor.slice_samples(start_sample=2, end_sample=7)


### PR DESCRIPTION
This PR was extracted as a prerequisite for #562 (switching `generate_dummy_imaging_extractor` to `GaussianNoiseImagingExtractor`). That PR had to remove `get_channel_names` from the consistency checks in `MultiImagingExtractor` and `VolumetricImagingExtractor` as a side effect of the dummy extractor switch, because `GaussianNoiseImagingExtractor` does not implement `get_num_channels` and the base class `get_channel_names` would raise an `AttributeError` at runtime. Separating this cleanup makes the motivation explicit and keeps #562 focused on the dummy extractor change.

The base `ImagingExtractor.get_channel_names` called `self.get_num_channels()`, which does not exist on the class, making it silently broken for any extractor that does not override it. Since all concrete extractors that meaningfully support channel names already have their own deprecated override, the base class implementation was only adding a footgun. `MemmapImagingExtractor` and `TiffImagingExtractor` were the two extractors that fell back to the broken base class implementation; they now have their own proper deprecated overrides.

All existing `get_channel_names` overrides in concrete extractors were missing docstrings. The base class docstring was being inherited, so removing the base method surfaced this gap. Docstrings have been added to all of them.

Tests asserting on channel name equality across paired imaging extractors have been removed, consistent with removing the consistency check.
